### PR TITLE
[A.Y. 2024/2025 Monaldini, Nicolò] Exercise: TCP Group Chat

### DIFF
--- a/snippets/__init__.py
+++ b/snippets/__init__.py
@@ -63,5 +63,8 @@ class Example:
 def find_examples(lab: int, example: int) -> Iterable[Example]:
     for name, path in EXAMPLES.items():
         if name.startswith('snippets.lab' + str(lab or "")):
-            if f'.example{example or ""}' in name:
+            if (
+                f'.example{example or ""}' in name or 
+                (example == '4' and name.endswith('.exercise_tcp_group_chat'))
+            ):
                 yield Example(name, path)

--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -1,0 +1,66 @@
+from snippets.lab3 import *
+from typing import Set
+import sys
+
+
+remote_peers: Set[Client] = set()
+
+def send_message(msg, sender):
+    if len(remote_peers) == 0:
+        print("No peer connected, message is lost")
+    elif msg:
+        for remote_peer in remote_peers:
+            remote_peer.send(message(msg.strip(), sender))
+    else:
+        print("Empty message, not sent")
+
+
+def on_message_received(event, payload, connection, error):
+    match event:
+        case 'message':
+            print(payload)
+        case 'close':
+            print(f"Connection with peer {connection.remote_address} closed")
+            remote_peers.remove(connection)
+        case 'error':
+            print(error)
+
+
+port = int(sys.argv[1])
+
+def on_new_connection(event, connection, address, error):
+    match event:
+        case 'listen':
+            print(f"Server listening on port {address[1]} at {', '.join(local_ips())}")
+        case 'connect':
+            print(f"Open ingoing connection from: {address}")
+            connection.callback = on_message_received
+            remote_peers.add(connection)
+        case 'stop':
+            print(f"Stop listening for new connections")
+        case 'error':
+            print(error)
+
+server = Server(port, on_new_connection)
+remote_endpoints = sys.argv[2:]
+
+for remote_endpoint in remote_endpoints:
+    try:
+        remote_peer = Client(address(remote_endpoint), on_message_received)
+        remote_peers.add(remote_peer)
+        print(f"Connected to {remote_peer.remote_address}")
+    except ConnectionRefusedError:
+        print(f"Connection to {remote_endpoint} refused")
+    except TimeoutError:
+        print(f"Connection to {remote_endpoint} timed out")
+
+try:
+    username = input('Enter your username to start the chat:\n')
+    print('Type your message and press Enter to send it. Messages from other peers will be displayed below.')
+    while True:
+        content = input()
+        send_message(content, username)
+except (EOFError, KeyboardInterrupt):
+        for remote_peer in remote_peers.copy():
+            remote_peer.close()
+server.close()


### PR DESCRIPTION
In this solution, every peers acts both as a server and as a client. Every peer has a Server() object to receive and accept connections, and instead of maintaing a single remote_peer variable, a set of remote_peers is used to manage multiple peers. This set is populated at start time with a Client() object for every endpoint specified via command line arguments, and more peers are added when users connects to the local endpoint. When a message is sent, it is forwarded to every peer in the remote_peers set. When a peer disconnects, it is removed from the set. In case of an EOFError or KeyboardInterrupt the script is gracefully terminated by closing the server and the connections with all the remote peers.

To run the script use the command:
poetry run python -m snippets -l 3 -e 4 PORT PEER1_IP:PEER1_PORT PEER2_IP:PEER2_PORT ... PEERn_IP:PEERn_PORT
(find_examples function was modified in snippets/__init__.py file to allow the execution of the script with poetry)

Example of a sample execution on localhost with 3 users:
    poetry run python -m snippets -l 3 -e 4 8080
    poetry run python -m snippets -l 3 -e 4 8081 localhost:8080
    poetry run python -m snippets -l 3 -e 4 8082 localhost:8080 localhost:8081