### PR TITLE
[A.Y. 2024/2025 Corradino, Bryan] Exercise: TCP Group Chat

### DIFF
--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -1,0 +1,82 @@
+from snippets.lab3 import *
+from typing import List
+import sys
+import socket
+
+EXIT_MESSAGE = "<HAS LEFT THE CHAT>"
+
+class TCPPeer:
+    def __init__(self, username, server_port, endpoints: List[str]=[]):
+        self.__username = username
+        self.__server = Server(server_port, self.__on_new_connection)
+        self.__peers: List[Client] = []
+        for endpoint in endpoints:
+            try:
+                self.__peers.append(Client(address(endpoint), self.__on_message_received))
+            except socket.error as e:
+                print(f"Failed to connect to {endpoint}, ignoring... ({e})")
+        if self.peers_count > 0:
+            print(f"Connected to:")
+            for peer in self.__peers:
+                print(f"- {peer.remote_address}")
+
+    def __on_message_received(self, event, payload, connection: Connection, error):
+        match event:
+            case 'message':
+                print(payload)
+            case 'close':
+                print(f"Connection with peer {connection.remote_address} closed")
+                self.__peers = list(filter(lambda p : p.remote_address != connection.remote_address, self.__peers))
+            case 'error':
+                print(error)
+
+    def __on_new_connection(self, event, connection: Connection, address, error):
+        match event:
+            case 'listen':
+                print(f"Server listening on port {address[0]} at {', '.join(local_ips())}")
+            case 'connect':
+                print(f"Open inbound connection from: {address}")
+                connection.callback = self.__on_message_received
+                self.__peers.append(connection)
+            case 'stop':
+                print(f"Stop listening for new connections")
+            case 'error':
+                print(error)
+
+    @property
+    def peers_count(self):
+        return len(self.__peers)
+
+    def broadcast(self, msg):
+        if self.peers_count == 0:
+            print("No peer connected, message is lost")
+        elif msg:
+            for peer in list(self.__peers):
+                try:
+                    peer.send(message(msg.strip(), self.__username))
+                except socket.error as e:
+                    self.__peers.remove(peer)
+                    print(f"Failed to deliver message to {peer.remote_address} ({e}). Peer removed.")
+        else:
+            print("Empty message, not sent")
+
+    def close_all_connections(self):
+        self.__server.close()
+        for peer in self.__peers:
+            peer.close()
+
+if __name__ == "__main__":
+    username = input('Enter your username to start the chat:\n')
+    peer = TCPPeer(username, server_port=int(sys.argv[1]), endpoints=sys.argv[2:])
+    print('Type your message and press Enter to send it. Messages from other peers will be displayed below.')
+    while True:
+        try:
+            content = input()
+            peer.broadcast(content)
+        except (EOFError, KeyboardInterrupt):
+            print("Leaving the chat...")
+            if peer.peers_count > 0:
+                peer.broadcast(EXIT_MESSAGE)
+            break
+    peer.close_all_connections()
+    exit(0)

--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -55,8 +55,7 @@ class TCPPeer:
                 try:
                     peer.send(message(msg.strip(), self.__username))
                 except socket.error as e:
-                    self.__peers.remove(peer)
-                    print(f"Failed to deliver message to {peer.remote_address} ({e}). Peer removed.")
+                    print(f"Failed to deliver message to {peer.remote_address} ({e}).")
         else:
             print("Empty message, not sent")
 


### PR DESCRIPTION
My implementation features a new class called `TCPPeer`, which models a peer holding a reference to every other remote peer participating in the chat. Much of the code provided in `example3_tcp_chat.py` has been refactored into the aforementioned class and adapted to handle multiple remote peers.

I've implemented some "safety" measures against the following cases:

- during initialization, any endpoints supplied as arguments to which a connection cannot be established will be ignored
- if a peer gracefully disconnects, the remaining TCPPeer instances will remove that peer from their active peers list to prevent communication with an invalid endpoint
- messages broadcast to an unresponsive peer (e.g., due of network issues), which would result in an exception if left unhandled, will simply not be delivered to that peer
  - this means that peers may not be aware of any unreceived messages in the event of network-related issues. If receiving messages in the order they are sent is not a strict requirement, this could be naively solved by having peers retry sending their undelivered messages at regular intervals to unresponsive peers until they finally time out, but I'm not sure this falls within the scope of this exercise
  - also, this phenomenon is rather tricky to test locally and, as such, I could not come up with a deterministic way to reliably trigger it

To test this script, you can launch multiple instances of it from within separate terminals by executing the following command:

`poetry run python exercise_tcp_group_chat.py PORT_C [IP_A:PORT_A IP_B:PORT_B]`

For instance:

- terminal 1: `poetry run python exercise_tcp_group_chat.py 9090`
- terminal 2: `poetry run python exercise_tcp_group_chat.py 9091 127.0.0.1:9090`
- terminal 3: `poetry run python exercise_tcp_group_chat.py 9092 127.0.0.1:9090 127.0.0.1:9091`