### PR TITLE
[A.Y. 2024/2025 Surname, Name] Exercise: TCP Group Chat

### DIFF
--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -1,0 +1,96 @@
+"""
+TCP Group Chat - Unificato Server e Client.
+"""
+
+import socket as s
+import threading as th
+import sys
+
+bufferSize = 1024
+
+# Funzioni per il Server
+def start_server(host, port):
+    addr = {}
+    clients = {}
+
+    def broadcast(message, sender=""):
+        for client in clients:
+            client.send(bytes(sender, "utf8") + message)
+
+    def handle_client(client):
+        name = client.recv(bufferSize).decode("utf8")
+        welcome_message = f"Welcome {name}! Type {{exit}} to leave the chat."
+        client.send(bytes(welcome_message, "utf8"))
+        broadcast(bytes(f"{name} joined the chat.", "utf8"))
+        clients[client] = name
+        while True:
+            message = client.recv(bufferSize)
+            if message == bytes("{exit}", "utf8"):
+                client.close()
+                del clients[client]
+                broadcast(bytes(f"{name} has left the chat.", "utf8"))
+                break
+            else:
+                broadcast(message, f"{name}: ")
+
+    server = s.socket(s.AF_INET, s.SOCK_STREAM)
+    server.bind((host, port))
+    server.listen(5)
+    print(f"Server started on {host}:{port}")
+    while True:
+        client, client_addr = server.accept()
+        print(f"Connection from {client_addr}")
+        addr[client] = client_addr
+        th.Thread(target=handle_client, args=(client,), daemon=True).start()
+
+# Funzioni per il Client
+def start_client(host, port):
+    global running
+    running = True
+
+    def receive_messages():
+        while running:
+            try:
+                message = client.recv(bufferSize).decode("utf8")
+                print(message)
+            except OSError:
+                break
+
+    def send_messages():
+        global running  # Dichiarazione esplicita
+        print("Inserisci il nome...")
+        while running:
+            try:
+                message = input()
+                client.send(bytes(message, "utf8"))
+                if message == "{exit}":
+                    client.close()
+                    running = False
+                    break
+            except OSError:
+                break
+
+    client = s.socket(s.AF_INET, s.SOCK_STREAM)
+    client.connect((host, port))
+    print(f"Connected to server at {host}:{port}")
+
+    th.Thread(target=receive_messages, daemon=True).start()
+    send_messages()
+
+# Main Entry Point
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python exercise_tcp_group_chat.py <server|client> <HOST> <PORT>")
+        sys.exit(1)
+
+    mode = sys.argv[1].lower()
+    host = sys.argv[2]
+    port = int(sys.argv[3])
+
+    if mode == "server":
+        start_server(host, port)
+    elif mode == "client":
+        start_client(host, port)
+    else:
+        print("Invalid mode. Use 'server' or 'client'.")
+        sys.exit(1)


### PR DESCRIPTION
This code implements a simple TCP-based group chat application in Python, enabling multiple clients to communicate with a server. The server facilitates communication by broadcasting messages received from one client to all connected clients. The application is composed of two main components: a server that handles client connections and manages message broadcasts, and a client that allows users to send and receive messages.

### Key Features and Choices

### Threading for Concurrent Handling
The server creates a separate thread for each client connection, allowing it to handle multiple clients simultaneously without blocking.
Similarly, the client uses a separate thread for receiving messages, enabling asynchronous message handling.

### Broadcast Messaging
The server broadcasts messages to all connected clients, excluding the sender for private messages.
A clients dictionary keeps track of connected sockets and associated usernames for personalized messaging.

### Graceful Shutdown
The server and clients handle interruptions (e.g., {exit} command or network errors) gracefully by closing sockets and removing clients from active lists.

### Ease of Use
The application includes user-friendly prompts and notifications, such as welcoming new users or informing others when someone leaves the chat.

### Buffer Size
A buffer size of 1024 bytes is used for message handling, suitable for small chat messages. This can be adjusted based on expected message sizes.


### Step to test: 
### Starting the Server 
Run the server in a terminal with the command: **python exercise_tcp_group_chat.py server <HOST> <PORT>**
### Connecting Clients
Open additional terminals and run the client with: **python exercise_tcp_group_chat.py client <HOST> <PORT>**
### Interacting
Enter a username when prompted.
Send messages to the chat; observe how the server broadcasts them to all connected clients.
Test the {exit} command to ensure clients disconnect gracefully.