### PR TITLE
[A.Y. 2024/2025 Barnes, Keith] Exercise: TCP Group Chat

### DIFF
--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -1,0 +1,89 @@
+import sys
+import threading
+from snippets.lab3 import *
+
+# Dictionary to store connected peers
+peers = {}
+
+def on_message_received(event, payload, connection, error):
+    match event:
+        case 'message':
+            print(f"Message from {connection.remote_address}: {payload}")
+            send_to_all(payload, sender_address=connection.remote_address)
+        case 'close':
+            print(f"Connection with {connection.remote_address} closed")
+            peers.pop(connection.remote_address, None)
+        case 'error':
+            print(f"Error with {connection.remote_address}: {error}")
+
+def send_to_all(message, sender_address=None):
+    for addr, conn in peers.items():
+        if addr != sender_address:
+            try:
+                conn.send(message)
+            except Exception as e:
+                print(f"Failed to send message to {addr}: {e}")
+                conn.close()
+                peers.pop(addr, None)
+
+def start_server(port):
+    def on_new_connection(event, connection, address, error):
+        match event:
+            case 'listen':
+                print(f"Server is listening on port {port} at {', '.join(local_ips())}")
+            case 'connect':
+                print(f"New connection from {address}")
+                connection.callback = on_message_received
+                peers[address] = connection
+            case 'stop':
+                print("Server has stopped listening.")
+            case 'error':
+                print(f"Server error: {error}")
+
+    server = Server(port, on_new_connection)
+    return server
+
+def connect_to_peer(remote_endpoint):
+    try:
+        client = Client(address(remote_endpoint), on_message_received)
+        print(f"Connected to peer at {client.remote_address}")
+        peers[client.remote_address] = client
+    except Exception as e:
+        print(f"Failed to connect to peer {remote_endpoint}: {e}")
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python script.py <port> [peer1] [peer2] ...")
+        sys.exit(1)
+
+    port = int(sys.argv[1])
+    remote_peers = sys.argv[2:]  # List of peer addresses
+
+    # Start the server
+    server = start_server(port)
+
+    # Attempt to connect to remote peers
+    for peer_addr in remote_peers:
+        threading.Thread(target=connect_to_peer, args=(peer_addr,), daemon=True).start()
+
+    username = input("Enter your username to start the chat:\n")
+    print("Type your message and press Enter to send. Type 'exit' to quit.")
+
+    try:
+        while True:
+            user_input = input()
+            if user_input.lower() == "exit":
+                break
+            formatted_message = message(user_input, username)
+            send_to_all(formatted_message)
+    except (KeyboardInterrupt, EOFError):
+        print("\nExiting chat...")
+    finally:
+        # Close all connections and stop the server
+        for conn in peers.values():
+            conn.close()
+        server.close()
+        print("Goodbye!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Decentralized Group Chat System

I developed a decentralized group chat system that allows multiple peers to connect and exchange messages in real time. Each peer operates as both a **server** (accepting incoming connections) and a **client** (initiating connections to other peers). When a peer sends a message, it is broadcast to all other connected peers, ensuring that all participants are updated immediately.

This approach was chosen for its **simplicity** and **scalability**. By allowing each peer to serve as both a client and a server, the system avoids the need for a centralized server and ensures flexible, decentralized communication. Additionally, **error handling** is implemented to manage disconnections or connection issues, keeping the system running smoothly even when peers leave or fail.

## Testing Instructions

1. Start the **First Peer** using:
    ```bash
    poetry run python snippets/lab3/exercise_tcp_group_chat.py PORT_A
    ```

2. Run subsequent **Peer** using:
    ```bash
    poetry run python snippets/lab3/exercise_tcp_group_chat.py PORT_B IP_A:PORT_A
    ```

    For example, if testing on the same machine, the three instances can be:
    ```bash
    poetry run python snippets/lab3/exercise_tcp_group_chat.py 5000
    poetry run python snippets/lab3/exercise_tcp_group_chat.py 5001 localhost:5000
    poetry run python snippets/lab3/exercise_tcp_group_chat.py 5002 localhost:5000
    ```

## Test Communication

- **Send a message** from one peer and confirm that it is displayed on all other connected peers.
- **Test message broadcasting** by sending messages from different peers and verifying that all connected peers receive the messages.
- **Disconnect a peer** by pressing `Ctrl+C` and verify that the remaining peers can continue messaging without issues.
- **Attempt to connect** using an invalid address and ensure that the system handles this error appropriately.

## Exit the Chat

- To exit the chat, type `exit` in any terminal.
- Alternatively, you can use `Ctrl+C` to stop the chat in any terminal, and the other peers should remain connected and able to continue chatting.

This system provides a **robust**, **decentralized** approach to group chat communication, with built-in **error handling** and **automatic connection management** to ensure continuous functionality even during peer disconnections or errors.
