### PR TITLE
[A.Y. 2024/2025 Moretti, Riccardo] Exercise: TCP Group Chat

### DIFF
--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -1,0 +1,39 @@
+from snippets.lab3 import *
+import sys
+
+
+def run_chat():
+    mode = sys.argv[1].lower()
+    global_peer = None
+
+    if mode == "server":
+        port = int(sys.argv[2])
+        global_peer = Peer("server", port=port, callback=on_message_received)
+        print(f"Chat server started on port {port}.")
+    elif mode == "client":
+        server_address = sys.argv[2]
+        global_peer = Peer("client", address=server_address, callback=on_message_received)
+        print(f"Connected to chat at {server_address}.")
+    else:
+        print("Invalid mode. Use 'server' or 'client'.")
+        return
+
+    username = input("Enter your username: ").strip()
+    print("Type your messages below. Press Ctrl+C to exit.\n"+
+          "_______________________________________________")
+    try:
+        while True:
+            content = input()
+            if content:
+                global_peer.send_chat_message(f"{username}: {content.strip()}")
+    except (EOFError, KeyboardInterrupt):
+        print("\nExiting chat.")
+
+
+def on_message_received(event, payload):
+    if event == "message":
+        print(payload)
+
+
+if __name__ == "__main__":
+    run_chat()


### PR DESCRIPTION
To run the Python code I used these two commands:
poetry run python .\snippets\lab3\exercise_tcp_group_chat.py server *port*
poetry run python .\snippets\lab3\exercise_tcp_group_chat.py client *address*:*port*

where you should replace the terms between "*" with a free port in the first case and that same port and the address given in the second.

I left the "server" "client" distinction even though the server acts as one only initially and behaves as both after the first connection, I imagined the "server" as the host of the group chat and the "client"s as the other who join later, they both are of the Peer class with different constructors.

For simplicity the server prints out it's address so it's easier to connect other peers first to his even though technically new peers could connect to any peer which would then broadcast the new address and port to the rest of the group chat.

Messages and events get broadcasted to other peers.