### PR TITLE
[A.Y. 2024/2025 Colletta, Lorenzo] Exercise: TCP Group ChatExercise lab3

### DIFF
--- a/snippets/lab3/README.md
+++ b/snippets/lab3/README.md
@@ -1,0 +1,19 @@
+# tcp group chat
+This project provides an implementation of a tcp group chat. Each peer acts both as a server, listening for connection requests, and as a client, initiating connections to other peers. A peer can only connect to other peers that are already running. In order to connect to a peer, you need to know its ip address and tcp port.
+
+## How to run:
+In order to run a peer
+
+    poetry run python -m exercise_tcp_group_chat <port> [<ip:port> ...]
+
+where:
+* <port>: is the the port of the peer
+* <ip:port>: is the ip address and tcp port of the peer you want to connect to
+
+### Example:
+
+    poetry run python -m exercise_tcp_group_chat 16000
+
+    poetry run python -m exercise_tcp_group_chat 16001 192.168.1.9:16000
+
+    poetry run python -m exercise_tcp_group_chat 16002 192.168.1.9:16001 192.168.1.9:16002

--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -32,6 +32,7 @@ def on_message_received(event, payload, connection, error):
             print(payload)
         case 'close':
             print(f"Connection with peer {connection.remote_address} closed")
+            message_forward(f"Connection with peer {connection.remote_address} closed", connection)
             global remote_peer; remote_peer.remove(connection)
         case 'error':
             print(error)
@@ -40,35 +41,37 @@ def on_message_received_server(event, payload, connection, error):
     match event:
         case 'message':
             print(payload)
-            message_forward(payload, connection)
+#            message_forward(payload, connection)
         case 'close':
             print(f"Connection with peer {connection.remote_address} closed")
-            message_forward(f"Connection with peer {connection.remote_address} closed", connection)
+#            message_forward(f"Connection with peer {connection.remote_address} closed", connection)
             global remote_peer; remote_peer.remove(connection)
         case 'error':
             print(error)
 
-if mode == 'server':
-    port = int(sys.argv[2])
+# define server side
+port = int(sys.argv[1])
 
-    def on_new_connection(event, connection, address, error):
-        match event:
-            case 'listen':
-                print(f"Server listening on port {address[0]} at {', '.join(local_ips())}")
-            case 'connect':
-                print(f"Open ingoing connection from: {address}")
-                connection.callback = on_message_received_server
-                global remote_peer; remote_peer.append(connection)
-            case 'stop':
-                print(f"Stop listening for new connections")
-            case 'error':
-                print(error)
+def on_new_connection(event, connection, address, error):
+    match event:
+        case 'listen':
+            print(f"Server listening on port {address[0]} at {', '.join(local_ips())}")
+        case 'connect':
+            print(f"Open ingoing connection from: {address}")
+            connection.callback = on_message_received_server
+            global remote_peer; remote_peer.append(connection)
+        case 'stop':
+            print(f"Stop listening for new connections")
+        case 'error':
+            print(error)
 
-    server = Server(port, on_new_connection)
-elif mode == 'client':
-    remote_endpoint = sys.argv[2]
+server = Server(port, on_new_connection)
 
-    remote_peer.append(Client(address(remote_endpoint), on_message_received))
+# define client side
+remote_endpoint = sys.argv[2:]
+for peer in remote_endpoint:
+    print(peer)
+    remote_peer.append(Client(address(peer), on_message_received))
     print(f"Connected to {remote_peer[0].remote_address}")
 
 username = input('Enter your username to start the chat:\n')

--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -15,12 +15,13 @@ def send_message(msg, sender):
     else:
         print("Empty message, not sent")
 
-def message_forward(msg):
+def message_forward(msg, connection_with_sender):
     if not remote_peer:
         print("No peer connected, message is lost")
     elif msg:
         for peer in remote_peer:
-            peer.send(msg)
+            if peer != connection_with_sender:
+                peer.send(msg)
     else:
         print("Empty message, not sent")
 

--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -1,0 +1,84 @@
+from snippets.lab3 import *
+import sys
+
+
+mode = sys.argv[1].lower().strip()
+remote_peer: list[Client] | list[Server] = []
+
+
+def send_message(msg, sender):
+    if not remote_peer:
+        print("No peer connected, message is lost")
+    elif msg:
+        for peer in remote_peer:
+            peer.send(message(msg.strip(), sender))
+    else:
+        print("Empty message, not sent")
+
+def message_forward(msg):
+    if not remote_peer:
+        print("No peer connected, message is lost")
+    elif msg:
+        for peer in remote_peer:
+            peer.send(msg)
+    else:
+        print("Empty message, not sent")
+
+
+def on_message_received(event, payload, connection, error):
+    match event:
+        case 'message':
+            print(payload)
+        case 'close':
+            print(f"Connection with peer {connection.remote_address} closed")
+            global remote_peer; remote_peer.remove(connection)
+        case 'error':
+            print(error)
+
+def on_message_received_server(event, payload, connection, error):
+    match event:
+        case 'message':
+            print(payload)
+            message_forward(payload, connection)
+        case 'close':
+            print(f"Connection with peer {connection.remote_address} closed")
+            global remote_peer; remote_peer.remove(connection)
+        case 'error':
+            print(error)
+
+if mode == 'server':
+    port = int(sys.argv[2])
+
+    def on_new_connection(event, connection, address, error):
+        match event:
+            case 'listen':
+                print(f"Server listening on port {address[0]} at {', '.join(local_ips())}")
+            case 'connect':
+                print(f"Open ingoing connection from: {address}")
+                connection.callback = on_message_received_server
+                global remote_peer; remote_peer.append(connection)
+            case 'stop':
+                print(f"Stop listening for new connections")
+            case 'error':
+                print(error)
+
+    server = Server(port, on_new_connection)
+elif mode == 'client':
+    remote_endpoint = sys.argv[2]
+
+    remote_peer.append(Client(address(remote_endpoint), on_message_received))
+    print(f"Connected to {remote_peer[0].remote_address}")
+
+username = input('Enter your username to start the chat:\n')
+print('Type your message and press Enter to send it. Messages from other peers will be displayed below.')
+while True:
+    try:
+        content = input()
+        send_message(content, username)
+    except (EOFError, KeyboardInterrupt):
+        if remote_peer:
+            for peer in remote_peer:
+                peer.close()
+        break
+if mode == 'server':
+    server.close()

--- a/snippets/lab3/exercise_tcp_group_chat.py
+++ b/snippets/lab3/exercise_tcp_group_chat.py
@@ -43,6 +43,7 @@ def on_message_received_server(event, payload, connection, error):
             message_forward(payload, connection)
         case 'close':
             print(f"Connection with peer {connection.remote_address} closed")
+            message_forward(f"Connection with peer {connection.remote_address} closed", connection)
             global remote_peer; remote_peer.remove(connection)
         case 'error':
             print(error)


### PR DESCRIPTION
# tcp group chat
This project provides an implementation of a tcp group chat. Each peer acts both as a server, listening for connection requests, and as a client, initiating connections to other peers. A peer can only connect to other peers that are already running. In order to connect to a peer, you need to know its ip address and tcp port.

## How to run:
In order to run a peer

    poetry run python -m exercise_tcp_group_chat <port> [<ip:port> ...]

where:
* <port>: is the the port of the peer
* <ip:port>: is the ip address and tcp port of the peer you want to connect to

### Example:

    poetry run python -m exercise_tcp_group_chat 16000

    poetry run python -m exercise_tcp_group_chat 16001 192.168.1.9:16000

    poetry run python -m exercise_tcp_group_chat 16002 192.168.1.9:16001 192.168.1.9:16002
