### PR TITLE
[A.Y. 2024/2025 Giangiulli, Chiara] Exercise: RPC Auth Service 1-2

### DIFF
--- a/snippets/lab4/example1_presentation.py
+++ b/snippets/lab4/example1_presentation.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import json
 from dataclasses import dataclass
 
-
 @dataclass
 class Request:
     """
@@ -12,6 +11,7 @@ class Request:
 
     name: str
     args: tuple
+    metadata: object | None
 
     def __post_init__(self):
         self.args = tuple(self.args)
@@ -87,6 +87,7 @@ class Serializer:
         return {
             'name': self._to_ast(request.name),
             'args': [self._to_ast(arg) for arg in request.args],
+            'metadata': self._to_ast(request.metadata),
         }
 
     def _response_to_ast(self, response: Response):
@@ -148,6 +149,7 @@ class Deserializer:
         return Request(
             name=self._ast_to_obj(data['name']),
             args=tuple(self._ast_to_obj(arg) for arg in data['args']),
+            metadata=self._ast_to_obj(data.get('metadata', None)),
         )
 
     def _ast_to_response(self, data):

--- a/snippets/lab4/example2_rpc_server.py
+++ b/snippets/lab4/example2_rpc_server.py
@@ -41,6 +41,14 @@ class ServerStub(Server):
     
     def __handle_request(self, request):
         try:
+            if request.name == 'get_user':
+                token = request.metadata
+                if not token or not self.__auth_service.validate_token(token):
+                    error = "Unauthorized: Token missing or invalid"
+                    return Response(None, error)
+                if token.user.role.name != "ADMIN":
+                    error = "Forbidden: Admin access required"
+                    return Response(None, error)
             if hasattr(self.__auth_service, request.name):
                 method = getattr(self.__auth_service, request.name)
             elif hasattr(self.__user_db, request.name):

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -6,12 +6,13 @@ from snippets.lab4.example1_presentation import serialize, deserialize, Request,
 class ClientStub:
     def __init__(self, server_address: tuple[str, int]):
         self.__server_address = address(*server_address)
+        self.token = None
 
     def rpc(self, name, *args):
         client = Client(self.__server_address)
         try:
             print('# Connected to %s:%d' % client.remote_address)
-            request = Request(name, args)
+            request = Request(name, args, self.token)
             print('# Marshalling', request, 'towards', "%s:%d" % client.remote_address)
             request = serialize(request)
             print('# Sending message:', request.replace('\n', '\n# '))
@@ -36,7 +37,8 @@ class RemoteUserDatabase(ClientStub, UserDatabase):
     def add_user(self, user: User):
         return self.rpc('add_user', user)
 
-    def get_user(self, id: str) -> User:
+    def get_user(self, id: str, token: Token) -> User:
+        self.token = token
         return self.rpc('get_user', id)
 
     def check_password(self, credentials: Credentials) -> bool:

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -43,7 +43,12 @@ if __name__ == '__main__':
                 user = User(args.user, args.email, args.name, Role[args.role.upper()], args.password)
                 print(user_db.add_user(user))
             case 'get':
-                print(user_db.get_user(ids[0]))
+                if args.path:
+                    with open(args.path, 'r') as file:
+                        token = file.read().strip()
+                else:
+                    raise ValueError("Your token path is required")
+                print(user_db.get_user(ids[0], deserialize(token)))
             case 'check':
                 credentials = Credentials(ids[0], args.password)
                 print(user_db.check_password(credentials))


### PR DESCRIPTION
# RPC Auth Service 1

### CHANGES:

- Implemented the serialization and deserialization of datetime objects (necessary to manage the expiration of authentication tokens) to allow them to be sent over the network.
(example1_presentation)

- On the server side (example2_rpc_server): added an authservice object for managing user authentication.

- On the client side (example3_rpc_client): added methods for login (authentication) and token validation (generated during login).

- Command-line interface (example4_rpc_client_cli): added `login` and `validate` commands with respective flags for managing the token (`-t`, `--path`).
The option to store the token in a file was made to simplify the process of entering it during validation.

### COMMANDS:

- `python -m snippets -l 4 -e 2 PORT`: to start the server

- `python -m snippets -l 4 -e 4 ADDRESS:PORT add -u username -a name.surname@gmail.com -n "Name Surname" -r admin -p "psswrd"`: on the client side, to add a user

- `python -m snippets -l 4 -e 4 ADDRESS:PORT login -u username -p "psswrd" --path username_token.json`: on the client side, to log in

- `python -m snippets -l 4 -e 4 ADDRESS:PORT validate -u username --path username_token.json`: on the client side, to validate the token (`--path` for the file, `-t` for the token).



# RPC Auth Service 2

### CHANGES:

To manage authorization for operations that require access to stored user information (`get`), a control has been introduced regarding the validity of the token of the user making the request (valid authentication) and their role (which must necessarily be admin):

- The Request class now includes a new field `metadata` which contains, when necessary, the token used for authorization control.

- Client-side: a field stores the token of the user making the get request, entered by the user from the command line, this allows multiple users to be logged in simultaneously.
This token is inserted into the metadata field of the client's Request.

- Server-side:  when the request is of the get user type, the token received in the metadata field is checked to authorize or not the operation (and, if authorized, to provide the requested information).

- The command-line interface has been updated to allow the token to be passed when making a get request (`--path`).

### COMMANDS:

- All previously available commands.

- `python -m snippets -l 4 -e 4 localhost:8080 get -u username --path user_token.json`
