### PR TITLE
[A.Y. 2024/2025 Pepe, Riccardo] Exercise: RPC Auth Service

### DIFF
--- a/snippets/lab4/example1_presentation.py
+++ b/snippets/lab4/example1_presentation.py
@@ -1,5 +1,5 @@
 from .users import User, Credentials, Token, Role
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 from dataclasses import dataclass
 
@@ -76,8 +76,18 @@ class Serializer:
             'expiration': self._to_ast(token.expiration),
         }
 
+    def _timedelta_to_ast(self, dt: timedelta):
+        return {
+            "days" : self._to_ast(dt.days),
+            "seconds" : self._to_ast(dt.seconds),
+            "microseconds" : self._to_ast(dt.microseconds)
+        }
+    
+    # Here i use the isoformat instead of year, month, day...
     def _datetime_to_ast(self, dt: datetime):
-        raise NotImplementedError("Missing implementation for datetime serialization")
+        return {
+            "datetime" : self._to_ast(dt.isoformat())
+        }
 
     def _role_to_ast(self, role: Role):
         return {'name': role.name}
@@ -137,8 +147,17 @@ class Deserializer:
             expiration=self._ast_to_obj(data['expiration']),
         )
 
+    def _ast_to_timedelta(self, data):
+        return timedelta(
+            days = self._ast_to_obj(data['days']),
+            seconds = self._ast_to_obj(data['seconds']),
+            microseconds = self._ast_to_obj(data['microseconds']),
+        )
+    
     def _ast_to_datetime(self, data):
-        raise NotImplementedError("Missing implementation for datetime deserialization")
+        return datetime.fromisoformat(
+            self._ast_to_obj(data['datetime'])
+        )
 
     def _ast_to_role(self, data):
         return Role[self._ast_to_obj(data['name'])]

--- a/snippets/lab4/example2_rpc_server.py
+++ b/snippets/lab4/example2_rpc_server.py
@@ -1,5 +1,6 @@
 from snippets.lab3 import Server
 from snippets.lab4.users.impl import InMemoryUserDatabase
+from snippets.lab4.users.impl import InMemoryAuthenticationService
 from snippets.lab4.example1_presentation import serialize, deserialize, Request, Response
 import traceback
 
@@ -8,6 +9,7 @@ class ServerStub(Server):
     def __init__(self, port):
         super().__init__(port, self.__on_connection_event)
         self.__user_db = InMemoryUserDatabase()
+        self.__user_auth = InMemoryAuthenticationService(self.__user_db)
     
     def __on_connection_event(self, event, connection, address, error):
         match event:
@@ -38,8 +40,14 @@ class ServerStub(Server):
     
     def __handle_request(self, request):
         try:
-            method = getattr(self.__user_db, request.name)
-            result = method(*request.args)
+            if (hasattr(self.__user_db, request.name)):
+                method = getattr(self.__user_db, request.name)
+                result = method(*request.args)
+            elif (hasattr(self.__user_auth, request.name)):
+                method = getattr(self.__user_auth, request.name)
+                result = method(*request.args)
+            else:
+                raise(AttributeError)
             error = None
         except Exception as e:
             result = None

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -41,6 +41,16 @@ class RemoteUserDatabase(ClientStub, UserDatabase):
 
     def check_password(self, credentials: Credentials) -> bool:
         return self.rpc('check_password', credentials)
+    
+class RemoteUserDatabaseAndAuthentication(RemoteUserDatabase, AuthenticationService):
+    def __init__(self, server_address):
+        super().__init__(server_address)
+
+    def authenticate(self, credentials, duration = None):
+        return self.rpc('authenticate', credentials, duration)
+    
+    def validate_token(self, token):
+        return self.rpc('validate_token', token)
 
 
 if __name__ == '__main__':

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -1,4 +1,4 @@
-from example3_rpc_client import *
+from snippets.lab4.example3_rpc_client import *
 import argparse
 import sys
 
@@ -7,10 +7,10 @@ TEST_EMAIL = "carlo@carlo.it"
 TEST_FULL_NAME = "CarloCarlo"
 TEST_CORRECT_PASS = "carlo"
 TEST_FAKE_PASS = "carlone"
-SERVER_PORT = 8080
+TEST_SERVER_PORT = 8080
 
 def test_add_user():
-    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=SERVER_PORT))
+    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=TEST_SERVER_PORT))
     user = User(TEST_USERNAME, TEST_EMAIL, TEST_FULL_NAME,
                 Role.USER, TEST_CORRECT_PASS)
     user_without_pass = User(TEST_USERNAME, TEST_EMAIL, TEST_FULL_NAME,
@@ -20,17 +20,17 @@ def test_add_user():
     assert obtained_user == user_without_pass
 
 def test_check_pass_correct_user():
-    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=SERVER_PORT))
+    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=TEST_SERVER_PORT))
     credentials = Credentials(TEST_USERNAME, TEST_CORRECT_PASS)
     assert user_db_auth.check_password(credentials=credentials)
 
 def test_check_pass_fake_user():
-    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=SERVER_PORT))
+    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=TEST_SERVER_PORT))
     credentials = Credentials(TEST_USERNAME, TEST_FAKE_PASS)
     assert not user_db_auth.check_password(credentials=credentials)
 
 def test_authenticate_user():
-    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=SERVER_PORT))
+    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=TEST_SERVER_PORT))
     credentials = Credentials(TEST_USERNAME, TEST_CORRECT_PASS)
     token = user_db_auth.authenticate(credentials=credentials, 
                                       duration=timedelta(days=1))

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -1,7 +1,41 @@
-from .example3_rpc_client import *
+from example3_rpc_client import *
 import argparse
 import sys
 
+TEST_USERNAME = "Carlo"
+TEST_EMAIL = "carlo@carlo.it"
+TEST_FULL_NAME = "CarloCarlo"
+TEST_CORRECT_PASS = "carlo"
+TEST_FAKE_PASS = "carlone"
+SERVER_PORT = 8080
+
+def test_add_user():
+    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=SERVER_PORT))
+    user = User(TEST_USERNAME, TEST_EMAIL, TEST_FULL_NAME,
+                Role.USER, TEST_CORRECT_PASS)
+    user_without_pass = User(TEST_USERNAME, TEST_EMAIL, TEST_FULL_NAME,
+                Role.USER)
+    user_db_auth.add_user(user)
+    obtained_user = user_db_auth.get_user(TEST_USERNAME)
+    assert obtained_user == user_without_pass
+
+def test_check_pass_correct_user():
+    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=SERVER_PORT))
+    credentials = Credentials(TEST_USERNAME, TEST_CORRECT_PASS)
+    assert user_db_auth.check_password(credentials=credentials)
+
+def test_check_pass_fake_user():
+    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=SERVER_PORT))
+    credentials = Credentials(TEST_USERNAME, TEST_FAKE_PASS)
+    assert not user_db_auth.check_password(credentials=credentials)
+
+def test_authenticate_user():
+    user_db_auth = RemoteUserDatabaseAndAuthentication(address(port=SERVER_PORT))
+    credentials = Credentials(TEST_USERNAME, TEST_CORRECT_PASS)
+    token = user_db_auth.authenticate(credentials=credentials, 
+                                      duration=timedelta(days=1))
+    assert user_db_auth.validate_token(token)
+    
 
 if __name__ == '__main__':
 

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -11,12 +11,14 @@ if __name__ == '__main__':
         exit_on_error=False,
     )
     parser.add_argument('address', help='Server address in the form ip:port')
-    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check'])
+    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check', 'authenticate', 'validate_token'])
     parser.add_argument('--user', '-u', help='Username')
     parser.add_argument('--email', '--address', '-a', nargs='+', help='Email address')
     parser.add_argument('--name', '-n', help='Full name')
     parser.add_argument('--role', '-r', help='Role (defaults to "user")', choices=['admin', 'user'])
     parser.add_argument('--password', '-p', help='Password')
+    parser.add_argument('--token', '-t', help='Token')
+    parser.add_argument('--expiration', help='Expiration date token')
 
     if len(sys.argv) > 1:
         args = parser.parse_args()
@@ -25,7 +27,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     args.address = address(args.address)
-    user_db = RemoteUserDatabase(args.address)
+    user_db_auth = RemoteUserDatabaseAndAuthentication(args.address)
 
     try :
         ids = (args.email or []) + [args.user]
@@ -38,12 +40,24 @@ if __name__ == '__main__':
                 if not args.name:
                     raise ValueError("Full name is required")
                 user = User(args.user, args.email, args.name, Role[args.role.upper()], args.password)
-                print(user_db.add_user(user))
+                print(user_db_auth.add_user(user))
             case 'get':
-                print(user_db.get_user(ids[0]))
+                print(user_db_auth.get_user(ids[0]))
             case 'check':
                 credentials = Credentials(ids[0], args.password)
-                print(user_db.check_password(credentials))
+                print(user_db_auth.check_password(credentials))
+            case 'authenticate':
+                credentials = Credentials(ids[0], args.password)
+                print(user_db_auth.authenticate(credentials))
+            case 'validate_token':
+                if not args.password:
+                    raise ValueError("Password is required")
+                if not args.name:
+                    raise ValueError("Full name is required")
+                user = User(args.user, args.email, args.name, Role[args.role.upper()], args.password)
+                token = Token(user, datetime.fromisoformat(args.expiration), 
+                              args.token)
+                print(user_db_auth.validate_token(token))
             case _:
                 raise ValueError(f"Invalid command '{args.command}'")
     except RuntimeError as e:


### PR DESCRIPTION
### Presentation
In the example1_presentation.py file _timedelta_to_ast, _datetime_to_ast, _ast_to_timedelta, _ast_to_datetime methods were implemented.  Datetime is represented with the iso format, in such a way that is much easier to decode than using individual fields like minutes, days, years...

### Server
In the server part has been introduced the InMemoryAuthenticationService was introduced which will work alongside InMemoryUserDatabase.

### Client
In the Client file, RemoteUserDatabse has been extended with the AuthenticationService in the RemoteUserDatabaseAndAuthentication class. 

### Client-CLI
In rpc_client_cli RemoteUserDatabse has been replaced with  RemoteUserDatabaseAndAuthentication, and now can handle --token and --expiration args.

### Tests
Tests have been added that simulate: adding a user, checking the password, the authentication step, and validating a token.
The following steps are necessary to perform system-related tests:
1) Start a server with the following command on the 8080 port:
`poetry run python -m snippets -l 4 -e 2  8080`
2) On a different shell go into the lab4 directory and start the tests with the following command:
`poetry run pytest -v example4_rpc_client_cli.py`
