### PR TITLE
[A.Y. 2024/2025 Casadei, Filippo] Exercise: RPC Auth Service 1 & 2

### DIFF
--- a/snippets/lab4/README.md
+++ b/snippets/lab4/README.md
@@ -9,7 +9,8 @@ The files present in snippets/lab4 were modified to implement both authenticatio
 ### ServerStub
 - The `ServerStub` was extended with a `InMemoryAuthenticationService` that will handle the requests of authentication and validation from a client
 - The `ServerStub` now can be initialized with a list of users. This list is necessary to perform operations on the server, as adding other users now requires authentication. In this case a single admin user is passed to the server
-- The `__handle_request` method has been modified so that only requests which contain a valid token can perform actions on the database. This means that when starting the server there must be already at least one user registered. Also only admin users can use the `get` and `check` methods, so that normal users cannot get the credentials of other users. Only admins can add other admins. 
+- The `__handle_request` method has been modified so that only requests which contain a valid token can perform actions on the database. This means that when starting the server there must be already at least one user registered. 
+- The method `__is_authorized` has been implemented to determine if a request can be fulfilled based on the role of the user making the request. Only admins can use the `get` and `check` methods and new admin users can only be added by other admins
 
 ### ClientStub
 - The `ClientStub` now has a `token` field which will be set to **None** if the user has not yet authenticated. This field will be used in the `metadata` field of every new `Request`

--- a/snippets/lab4/README.md
+++ b/snippets/lab4/README.md
@@ -1,0 +1,66 @@
+# Description
+
+The files present in snippets/lab4 were modified to implement both authentication and authorization of users.
+
+### Request and serialization
+- A dictionary field `metadata` was added to the `Request` dataclass
+- Implemented serialization of datetime type in `Serializer` and `Deserializer` classes 
+
+### ServerStub
+- The `ServerStub` was extended with a `InMemoryAuthenticationService` that will handle the requests of authentication and validation from a client
+- The `ServerStub` now can be initialized with a list of users. This list is necessary to perform operations on the server, as adding other users now requires authentication. In this case a single admin user is passed to the server
+- The `__handle_request` method has been modified so that only requests which contain a valid token can perform actions on the database. This means that when starting the server there must be already at least one user registered. Also only admin users can use the `get` and `check` methods, so that normal users cannot get the credentials of other users. Only admins can add other admins. 
+
+### ClientStub
+- The `ClientStub` now has a `token` field which will be set to **None** if the user has not yet authenticated. This field will be used in the `metadata` field of every new `Request`
+- The methods `store_token` and  `get_token` were implemented
+- A new class `RemoteAuthenticationService` which extends the `ClientStub` was implemented to perform authentication and validation requests
+
+### Command Line
+- A new flag `--token` was added. It has to be used in case the user wants to specify the path were the token will be saved and/or retrieved at each execution. If no path is provided then the default location will be used
+- The following commands were added:
+    1) **authenticate**: if the credentials are correct, stores the returned token inside the `RemoteUserDatabase` and the `RemoteAuthenticationService`.
+    Since these are recreated at each execution, the token is also saved to a file
+    2) **validate**: checks if the specified token is still valid
+    3) **delete_token**: which deletes the specified token, so that no other user will be able to use it
+
+# How to test
+
+To get started, **you must first start the server**
+
+```
+python -m snippets -l 4 -e 2 server_port
+```
+
+Running any command before authenticating will now return an error, so initially the user must use the command `authenticate` as follows:
+
+```
+python -m snippets -l 4 -e 4 server_address:server_port authenticate -u username -p password
+```
+It's also possible to use the email address instead of the username.
+
+The commands `validate` and `delete_token` can be used as follows
+
+```
+python -m snippets -l 4 -e 4 server_address:server_port validate
+
+python -m snippets -l 4 -e 4 server_address:server_port delete_token
+```
+
+The flag `--token` or `-t` can be used to specify where the token should be saved when using the `authenticate`. In this case the user has to specify the token path every time they execute any other command.
+
+For example, if a user authenticates by specifying a token path and then wants to execute the `get` command, they should do as follows:
+
+```
+python -m snippets -l 4 -e 4 server_address:server_port authenticate -u username -p password -t token_path
+
+python -m snippets -l 4 -e 4 server_address:server_port check -u username -t token_path
+```
+
+
+As mentioned earlier, initially the only registered user on the server is the admin, so to perform any actions you must authenticate using the following credentials.
+- username: admin
+- emails: admin@mail.com
+- full_name: Admin
+- role: ADMIN
+- password: qwerty1234 

--- a/snippets/lab4/example1_presentation.py
+++ b/snippets/lab4/example1_presentation.py
@@ -12,6 +12,7 @@ class Request:
 
     name: str
     args: tuple
+    metadata: dict
 
     def __post_init__(self):
         self.args = tuple(self.args)
@@ -77,7 +78,7 @@ class Serializer:
         }
 
     def _datetime_to_ast(self, dt: datetime):
-        raise NotImplementedError("Missing implementation for datetime serialization")
+        return {'datetime': dt.isoformat()}
 
     def _role_to_ast(self, role: Role):
         return {'name': role.name}
@@ -86,6 +87,7 @@ class Serializer:
         return {
             'name': self._to_ast(request.name),
             'args': [self._to_ast(arg) for arg in request.args],
+            'metadata': self._to_ast(request.metadata),
         }
 
     def _response_to_ast(self, response: Response):
@@ -138,7 +140,7 @@ class Deserializer:
         )
 
     def _ast_to_datetime(self, data):
-        raise NotImplementedError("Missing implementation for datetime deserialization")
+        return datetime.fromisoformat(data['datetime'])
 
     def _ast_to_role(self, data):
         return Role[self._ast_to_obj(data['name'])]
@@ -147,6 +149,7 @@ class Deserializer:
         return Request(
             name=self._ast_to_obj(data['name']),
             args=tuple(self._ast_to_obj(arg) for arg in data['args']),
+            metadata=self._ast_to_obj(data['metadata']),
         )
 
     def _ast_to_response(self, data):

--- a/snippets/lab4/example2_rpc_server.py
+++ b/snippets/lab4/example2_rpc_server.py
@@ -50,11 +50,8 @@ class ServerStub(Server):
                 if request.metadata['token'] is None:
                     raise ValueError("Token is required")
                 elif self.__auth_service.validate_token(request.metadata['token']): # Checks if the token is valid
-                    if request.name in ["get_user", "check_password"] and request.metadata['token'].user.role != Role.ADMIN:
-                        raise ValueError("Only admins can get user information")
-                    elif request.name in ["add_user"] and (request.metadata['token'].user.role != Role.ADMIN and request.args[0].role == Role.ADMIN):
-                        raise ValueError("Only admins can add other admins")
-                    method = getattr(self.__user_db, request.name)
+                    if self.__is_authorized(request):
+                        method = getattr(self.__user_db, request.name)
                 else:
                     raise ValueError("Invalid token")
             else:
@@ -66,6 +63,12 @@ class ServerStub(Server):
             error = " ".join(e.args)
         return Response(result, error)
 
+    def __is_authorized(self, request):
+        if request.name in ["get_user", "check_password"] and request.metadata['token'].user.role != Role.ADMIN:
+            raise ValueError("Only admins can get user information")
+        elif request.name in ["add_user"] and (request.metadata['token'].user.role != Role.ADMIN and request.args[0].role == Role.ADMIN):
+            raise ValueError("Only admins can add other admins")
+        return True 
 
 if __name__ == '__main__':
     import sys

--- a/snippets/lab4/example2_rpc_server.py
+++ b/snippets/lab4/example2_rpc_server.py
@@ -1,13 +1,19 @@
 from snippets.lab3 import Server
-from snippets.lab4.users.impl import InMemoryUserDatabase
+from snippets.lab4.users.impl import InMemoryUserDatabase, InMemoryAuthenticationService
+from snippets.lab4.users import User, Role
 from snippets.lab4.example1_presentation import serialize, deserialize, Request, Response
+from typing import List
 import traceback
 
 
 class ServerStub(Server):
-    def __init__(self, port):
+    def __init__(self, port, admins: List[User] = []):
         super().__init__(port, self.__on_connection_event)
         self.__user_db = InMemoryUserDatabase()
+        self.__auth_service = InMemoryAuthenticationService(self.__user_db, debug=True)
+        for admin in admins:
+            self.__user_db.add_user(admin)
+        
     
     def __on_connection_event(self, event, connection, address, error):
         match event:
@@ -49,7 +55,10 @@ class ServerStub(Server):
 
 if __name__ == '__main__':
     import sys
-    server = ServerStub(int(sys.argv[1]))
+    # Default admin user
+    admin = User(username="admin", emails={"admin@mail.com"}, full_name="Admin", role=Role.ADMIN, password="qwerty1234")
+    
+    server = ServerStub(int(sys.argv[1]), [admin])
     while True:
         try:
             input('Close server with Ctrl+D (Unix) or Ctrl+Z (Win)\n')

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -45,6 +45,17 @@ class RemoteUserDatabase(ClientStub, UserDatabase):
 
     def check_password(self, credentials: Credentials) -> bool:
         return self.rpc('check_password', credentials)
+    
+class RemoteAuthenticationService(ClientStub, AuthenticationService):
+    
+    def __init__(self, server_address, token: Token = None):
+        super().__init__(server_address, token)
+    
+    def authenticate(self, credentials: Credentials) -> Token:
+        return self.rpc('authenticate', credentials)
+    
+    def validate_token(self, token: Token) -> bool:
+        return self.rpc('validate_token', token)
 
 
 if __name__ == '__main__':

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -4,14 +4,15 @@ from snippets.lab4.example1_presentation import serialize, deserialize, Request,
 
 
 class ClientStub:
-    def __init__(self, server_address: tuple[str, int]):
+    def __init__(self, server_address: tuple[str, int], token: Token = None):
         self.__server_address = address(*server_address)
+        self.__token = token
 
     def rpc(self, name, *args):
         client = Client(self.__server_address)
         try:
             print('# Connected to %s:%d' % client.remote_address)
-            request = Request(name, args)
+            request = Request(name, args, {'token': self.__token})
             print('# Marshalling', request, 'towards', "%s:%d" % client.remote_address)
             request = serialize(request)
             print('# Sending message:', request.replace('\n', '\n# '))
@@ -27,11 +28,14 @@ class ClientStub:
         finally:
             client.close()
             print('# Disconnected from %s:%d' % client.remote_address)
+            
+    def store_token(self, token: Token):
+        self.__token = token
 
 
 class RemoteUserDatabase(ClientStub, UserDatabase):
-    def __init__(self, server_address):
-        super().__init__(server_address)
+    def __init__(self, server_address, token: Token = None):
+        super().__init__(server_address, token)
 
     def add_user(self, user: User):
         return self.rpc('add_user', user)

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -31,7 +31,9 @@ class ClientStub:
             
     def store_token(self, token: Token):
         self.__token = token
-
+        
+    def get_token(self):
+        return self.__token.copy()
 
 class RemoteUserDatabase(ClientStub, UserDatabase):
     def __init__(self, server_address, token: Token = None):

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -3,6 +3,18 @@ import argparse
 import os
 import sys
 
+# Ensures that the token filepath is a json file
+def ensure_json_file(filepath):
+    if not filepath.endswith('.json'):
+        if '.' in os.path.basename(filepath):
+            filepath = os.path.splitext(filepath)[0] + '.json'
+        else:
+            filepath = os.path.join(filepath, 'token.json')
+    if not os.path.exists(os.path.dirname(filepath)):
+        print(f"Directory {os.path.dirname(filepath)} does not exist")
+        print("Using the current directory instead")
+        filepath = os.path.basename(filepath)
+    return filepath
 
 if __name__ == '__main__':
 
@@ -28,8 +40,8 @@ if __name__ == '__main__':
 
     args.address = address(args.address)
     
-    token_path = args.token or './token.json'
-        
+    token_path = ensure_json_file(args.token or './')
+    
     try:
         with open(token_path) as f:
             token = deserialize(f.read())
@@ -74,6 +86,7 @@ if __name__ == '__main__':
             case 'validate':
                 print("Given token is valid" if user_auth.validate_token(token) else "Given token is invalid")
             case 'delete_token':
+                # Deletes only the token file because the ClientStub gets generated at every execution
                 if os.path.exists(token_path):
                     os.remove(token_path)
                 else:

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -17,6 +17,7 @@ if __name__ == '__main__':
     parser.add_argument('--name', '-n', help='Full name')
     parser.add_argument('--role', '-r', help='Role (defaults to "user")', choices=['admin', 'user'])
     parser.add_argument('--password', '-p', help='Password')
+    parser.add_argument('--token', '-t', help='Token Path')
 
     if len(sys.argv) > 1:
         args = parser.parse_args()
@@ -25,7 +26,21 @@ if __name__ == '__main__':
         sys.exit(0)
 
     args.address = address(args.address)
-    user_db = RemoteUserDatabase(args.address)
+    
+    token_path = args.token or './token.json'
+        
+    try:
+        with open(token_path) as f:
+            token = deserialize(f.read())
+            if not isinstance(token, Token):
+                print("Token is corrupted")
+                token = None
+    except FileNotFoundError:
+        token = None
+        print("Token file not provided\n")
+    
+    user_db = RemoteUserDatabase(args.address, token)
+    user_auth = RemoteAuthenticationService(args.address, token)
 
     try :
         ids = (args.email or []) + [args.user]

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -1,5 +1,6 @@
 from .example3_rpc_client import *
 import argparse
+import os
 import sys
 
 
@@ -11,7 +12,7 @@ if __name__ == '__main__':
         exit_on_error=False,
     )
     parser.add_argument('address', help='Server address in the form ip:port')
-    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check'])
+    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check', 'authenticate', 'validate', 'delete_token'])
     parser.add_argument('--user', '-u', help='Username')
     parser.add_argument('--email', '--address', '-a', nargs='+', help='Email address')
     parser.add_argument('--name', '-n', help='Full name')
@@ -53,12 +54,30 @@ if __name__ == '__main__':
                 if not args.name:
                     raise ValueError("Full name is required")
                 user = User(args.user, args.email, args.name, Role[args.role.upper()], args.password)
-                print(user_db.add_user(user))
+                response = user_db.add_user(user)
+                print("User added successfully" if response is None else response)
             case 'get':
                 print(user_db.get_user(ids[0]))
             case 'check':
                 credentials = Credentials(ids[0], args.password)
                 print(user_db.check_password(credentials))
+            case 'authenticate':
+                credentials = Credentials(ids[0], args.password)
+                response = user_auth.authenticate(credentials)
+                print(response)
+                if response is not None:
+                    user_db.store_token(response) # When authenticated the new token is stored and will be used for further requests
+                    user_auth.store_token(response)
+                    with open(token_path, 'w') as f:
+                        f.write(serialize(response)) # Save the token to a file, overwriting the previous one if present
+                        print(f'Token saved to {token_path}')
+            case 'validate':
+                print("Given token is valid" if user_auth.validate_token(token) else "Given token is invalid")
+            case 'delete_token':
+                if os.path.exists(token_path):
+                    os.remove(token_path)
+                else:
+                    print("Error: couldn't find the token file")
             case _:
                 raise ValueError(f"Invalid command '{args.command}'")
     except RuntimeError as e:


### PR DESCRIPTION
# Description

The files present in snippets/lab4 were modified to implement both authentication and authorization of users.

### Request and serialization
- A dictionary field `metadata` was added to the `Request` dataclass
- Implemented serialization of datetime type in `Serializer` and `Deserializer` classes 

### ServerStub
- The `ServerStub` was extended with a `InMemoryAuthenticationService` that will handle the requests of authentication and validation from a client
- The `ServerStub` now can be initialized with a list of users. This list is necessary to perform operations on the server, as adding other users now requires authentication. In this case a single admin user is passed to the server
- The `__handle_request` method has been modified so that only requests which contain a valid token can perform actions on the database. This means that when starting the server there must be already at least one user registered. 
- The method `__is_authorized` has been implemented to determine if a request can be fulfilled based on the role of the user making the request. Only admins can use the `get` and `check` methods and new admin users can only be added by other admins

### ClientStub
- The `ClientStub` now has a `token` field which will be set to **None** if the user has not yet authenticated. This field will be used in the `metadata` field of every new `Request`
- The methods `store_token` and  `get_token` were implemented
- A new class `RemoteAuthenticationService` which extends the `ClientStub` was implemented to perform authentication and validation requests

### Command Line
- A new flag `--token` was added. It has to be used in case the user wants to specify the path were the token will be saved and/or retrieved at each execution. If no path is provided then the default location will be used
- The following commands were added:
    1) **authenticate**: if the credentials are correct, stores the returned token inside the `RemoteUserDatabase` and the `RemoteAuthenticationService`.
    Since these are recreated at each execution, the token is also saved to a file
    2) **validate**: checks if the specified token is still valid
    3) **delete_token**: which deletes the specified token, so that no other user will be able to use it

# How to test

To get started, **you must first start the server**

```
python -m snippets -l 4 -e 2 server_port
```

Running any command before authenticating will now return an error, so initially the user must use the command `authenticate` as follows:

```
python -m snippets -l 4 -e 4 server_address:server_port authenticate -u username -p password
```
It's also possible to use the email address instead of the username.

The commands `validate` and `delete_token` can be used as follows

```
python -m snippets -l 4 -e 4 server_address:server_port validate

python -m snippets -l 4 -e 4 server_address:server_port delete_token
```

The flag `--token` or `-t` can be used to specify where the token should be saved when using the `authenticate`. In this case the user has to specify the token path every time they execute any other command.

For example, if a user authenticates by specifying a token path and then wants to execute the `get` command, they should do as follows:

```
python -m snippets -l 4 -e 4 server_address:server_port authenticate -u username -p password -t token_path

python -m snippets -l 4 -e 4 server_address:server_port check -u username -t token_path
```


As mentioned earlier, initially the only registered user on the server is the admin, so to perform any actions you must authenticate using the following credentials.
- username: admin
- emails: admin@mail.com
- full_name: Admin
- role: ADMIN
- password: qwerty1234 