### PR TITLE
[A.Y. 2024/2025 Severi, Tommaso & Sanchi, Emanuele] Exercise: RPC Auth Service 1 & 2

### DIFF
--- a/snippets/lab4/example1_presentation.py
+++ b/snippets/lab4/example1_presentation.py
@@ -12,6 +12,7 @@ class Request:
 
     name: str
     args: tuple
+    metadata: dict = None
 
     def __post_init__(self):
         self.args = tuple(self.args)

--- a/snippets/lab4/example1_presentation.py
+++ b/snippets/lab4/example1_presentation.py
@@ -77,7 +77,9 @@ class Serializer:
         }
 
     def _datetime_to_ast(self, dt: datetime):
-        raise NotImplementedError("Missing implementation for datetime serialization")
+        return {
+            'date': self._to_ast(dt.strftime('%Y-%m-%d %H:%M:%S.%f'))
+        }
 
     def _role_to_ast(self, role: Role):
         return {'name': role.name}
@@ -138,7 +140,7 @@ class Deserializer:
         )
 
     def _ast_to_datetime(self, data):
-        raise NotImplementedError("Missing implementation for datetime deserialization")
+        return self._ast_to_obj(datetime.strptime(data['date'], '%Y-%m-%d %H:%M:%S.%f'))
 
     def _ast_to_role(self, data):
         return Role[self._ast_to_obj(data['name'])]

--- a/snippets/lab4/example2_rpc_server.py
+++ b/snippets/lab4/example2_rpc_server.py
@@ -7,7 +7,7 @@ import traceback
 class ServerStub(Server):
     def __init__(self, port):
         super().__init__(port, self.__on_connection_event)
-        self.__user_db = InMemoryUserDatabase()
+        self.__user_db = InMemoryUserDatabase(True)
     
     def __on_connection_event(self, event, connection, address, error):
         match event:
@@ -39,7 +39,11 @@ class ServerStub(Server):
     def __handle_request(self, request):
         try:
             method = getattr(self.__user_db, request.name)
-            result = method(*request.args)
+            result = None
+            if (request.metadata == None):
+                result = method(*request.args)
+            else:
+                result = method(*request.args, request.metadata)
             error = None
         except Exception as e:
             result = None

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -42,6 +42,15 @@ class RemoteUserDatabase(ClientStub, UserDatabase):
     def check_password(self, credentials: Credentials) -> bool:
         return self.rpc('check_password', credentials)
 
+class RemoteUserAuthentication(ClientStub, AuthenticationService):
+    def __init__(self, server_address):
+        super().__init__(server_address)
+
+    def authenticate(self, credentials: Credentials) -> Token:
+        return self.rpc('authenticate', credentials)
+
+    def validate_token(self, token: Token) -> bool:
+        return self.rpc('validate_token', token)
 
 if __name__ == '__main__':
     from snippets.lab4.example0_users import gc_user, gc_credentials_ok, gc_credentials_wrong

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -1,33 +1,9 @@
 from .example3_rpc_client import *
 import argparse
+import shlex
 import sys
 
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser(
-        prog=f'python -m snippets -l 4 -e 4',
-        description='RPC client for user database',
-        exit_on_error=False,
-    )
-    parser.add_argument('address', help='Server address in the form ip:port')
-    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check', 'auth'])
-    parser.add_argument('--user', '-u', help='Username')
-    parser.add_argument('--email', '--address', '-a', nargs='+', help='Email address')
-    parser.add_argument('--name', '-n', help='Full name')
-    parser.add_argument('--role', '-r', help='Role (defaults to "user")', choices=['admin', 'user'])
-    parser.add_argument('--password', '-p', help='Password')
-
-    if len(sys.argv) > 1:
-        args = parser.parse_args()
-    else:
-        parser.print_help()
-        sys.exit(0)
-
-    args.address = address(args.address)
-    user_db = RemoteUserDatabase(args.address)
-    user_auth = RemoteUserAuthentication(args.address)
-
+def execute(args, user_db: RemoteUserDatabase, user_auth: RemoteUserAuthentication):
     try :
         ids = (args.email or []) + [args.user]
         if len(ids) == 0:
@@ -41,7 +17,7 @@ if __name__ == '__main__':
                 user = User(args.user, args.email, args.name, Role[args.role.upper()], args.password)
                 print(user_db.add_user(user))
             case 'get':
-                print(user_db.get_user(ids[0]))
+                print(user_db.get_user(ids[0], user_auth.token))
             case 'check':
                 credentials = Credentials(ids[0], args.password)
                 print(user_db.check_password(credentials))
@@ -52,3 +28,51 @@ if __name__ == '__main__':
                 raise ValueError(f"Invalid command '{args.command}'")
     except RuntimeError as e:
         print(f'[{type(e).__name__}]', *e.args)
+
+if __name__ == '__main__':
+    
+    args = None
+    user_db = None
+    user_auth = None
+
+    parser = argparse.ArgumentParser(
+        prog=f'python -m snippets -l 4 -e 4',
+        description='RPC client for user database',
+        exit_on_error=False,
+    )
+    
+    parser.add_argument('address', help='Server address in the form ip:port')
+    
+    if (len(sys.argv) > 1):
+        args = parser.parse_args(sys.argv[1:])
+        user_db = RemoteUserDatabase(address(args.address))
+        user_auth = RemoteUserAuthentication(address(args.address))
+    else:
+        parser.print_help()
+        sys.exit(1)
+        
+    parser = argparse.ArgumentParser(
+        description='RPC client for user database',
+        exit_on_error=False,
+    )
+    
+    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check', 'auth'])
+    parser.add_argument('--user', '-u', help='Username')
+    parser.add_argument('--email', '--address', '-a', nargs='+', help='Email address')
+    parser.add_argument('--name', '-n', help='Full name')
+    parser.add_argument('--role', '-r', help='Role (defaults to "user")', choices=['admin', 'user'])
+    parser.add_argument('--password', '-p', help='Password')
+
+    parser.print_help()
+
+    while True:
+        try:
+            print()
+            user_input = input('Enter command: ')
+            if user_input.strip():
+                args = parser.parse_args(shlex.split(user_input))
+                execute(args, user_db, user_auth)
+            else:
+                parser.print_help()
+        except (EOFError, KeyboardInterrupt):
+            sys.exit(0)

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
         exit_on_error=False,
     )
     parser.add_argument('address', help='Server address in the form ip:port')
-    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check'])
+    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check', 'auth'])
     parser.add_argument('--user', '-u', help='Username')
     parser.add_argument('--email', '--address', '-a', nargs='+', help='Email address')
     parser.add_argument('--name', '-n', help='Full name')
@@ -26,6 +26,7 @@ if __name__ == '__main__':
 
     args.address = address(args.address)
     user_db = RemoteUserDatabase(args.address)
+    user_auth = RemoteUserAuthentication(args.address)
 
     try :
         ids = (args.email or []) + [args.user]
@@ -44,6 +45,9 @@ if __name__ == '__main__':
             case 'check':
                 credentials = Credentials(ids[0], args.password)
                 print(user_db.check_password(credentials))
+            case 'auth':
+                credentials = Credentials(ids[0], args.password)
+                print(user_auth.authenticate(credentials))
             case _:
                 raise ValueError(f"Invalid command '{args.command}'")
     except RuntimeError as e:

--- a/snippets/lab4/users/__init__.py
+++ b/snippets/lab4/users/__init__.py
@@ -72,9 +72,6 @@ class UserDatabase(Protocol):
     
     def check_password(self, credentials: Credentials) -> bool:
         ...
-        
-    def auth_user(self, credentials: Credentials) -> User:
-        ...
 
 
 class AuthenticationService(Protocol):

--- a/snippets/lab4/users/__init__.py
+++ b/snippets/lab4/users/__init__.py
@@ -72,6 +72,9 @@ class UserDatabase(Protocol):
     
     def check_password(self, credentials: Credentials) -> bool:
         ...
+        
+    def auth_user(self, credentials: Credentials) -> User:
+        ...
 
 
 class AuthenticationService(Protocol):

--- a/snippets/lab4/users/impl.py
+++ b/snippets/lab4/users/impl.py
@@ -53,6 +53,14 @@ class InMemoryUserDatabase(UserDatabase, _Debuggable):
         self._log(f"Checking {credentials}: {'correct' if result else 'incorrect'}")
         return result
     
+    def authenticate(self, credentials: Credentials) -> User:
+        self._log("Authentication user:", credentials)
+        authService = InMemoryAuthenticationService(self, debug=True)
+        token = authService.authenticate(credentials)
+        if authService.validate_token(token):
+            return token
+        raise ValueError("Invalid credentials")
+    
 
 class InMemoryAuthenticationService(AuthenticationService, _Debuggable):
     def __init__(self, database: UserDatabase, secret: str = None, debug: bool = True):


### PR DESCRIPTION
We start by prefacing that we were authorized by prof. Ciatto Giovanni to work in group for this pull request.

# Solution

### Auth Service 1
In order to implement the authentication we added "auth" in the list of possible commands to be executed by the client.
Server-side we added the "authenticate" method in the class "InMemoryUserDatabase" that uses the reference of the "InMemoryAuthenticationService" that checks if the user is saved in the database and if the password used is correct.
If all checks pass without errors a new Token is created and sent back to the client.

### Auth Service 2
To restrict the "get" method to only the authorized and authenticated users we started by adding the "metadata" field, containing the possible token, to the requests sent by the client to the server. If the token is validated by the "InMemoryAuthenticationService" instance and the user assigned to the token has the role of an ADMIN then the informations are returned correctly.
We also needed to implement the serialization and de-serialization of the new metadata field containing a "datetime" that is converted to string when is sent in the request.
The "RemoteUserAuthentication" class was fitted to contain a new private field, initialized to "None", for the token, written upon authentication and accessible as a property of the class when needed.

# Choices
In order to save the token across executions we decided to make the client-side code never-ending, so that only the server ip and port are needed as parameters. All the commands that are used to interact with the server need to be executed while the program is already running.
We decided to leave all the permissions checking to the server, leaving the client clueless of the validity of it's actions. The token and role of the user are all done by the "InMemoryUserDatabase" class with the help of "InMemoryAuthenticationService".
Since the "InMemoryAuthenticationService" needed to check the database before creating a new token we decided that an authentication server exclusive token should be created beforehand to accompany the request. This also meant that a single instance of the "InMemoryAuthenticationService" is used by the database.

# Testing
To test the solution run on a shell acting as the server this command:
`python -m snippets -l 4 -e 2 PORT`
Then start another shell acting as a client:
`python -m snippets -l 4 -e 4 SERVER_IP:PORT`
Then a series of commands can be executed (help is displayed upon launch)

### Auth Service 1
In order to test the first part of the exercise run this commands in order:
1. `add -u test -a test.test@unibo.it test@gmail.com -n "Test Test" -r admin -p "test"`
2. `auth -u test -p "test"`
If everything works fine the Token should be displayed a the response of the server.

### Auth Service 2
Start by executing the same commands as before and execute right after:
`get -u test`
This should display all the informations about the user test.
Then try creating a new non-admin user changing the role to "user" and authenticating with this new account.
After this, if the get command is executed an error should be displayed.
If the client is stopped and re-executed if the "get" is used before authentication the same error should be displayed.