### PR TITLE
[A.Y. 2024/2025 Colletta, Lorenzo] Exercise: RPC Auth Service 2

### DIFF
--- a/snippets/lab4/README.md
+++ b/snippets/lab4/README.md
@@ -23,7 +23,7 @@ python -m snippets -l 4 -e 4 SERVER_IP:PORT auth -u name -p password [-tp] [--to
 
 Token validation command:
 ```bash
-python -m snippets -l 4 -e 4 SERVER_IP:PORT validate -u name -p password [-tp] [--tokenPath filepath]
+python -m snippets -l 4 -e 4 SERVER_IP:PORT validate -tp filepath
 ```
 where:
 * SERVER_IP (e.g. localhost) is the IP address of the server;

--- a/snippets/lab4/README.md
+++ b/snippets/lab4/README.md
@@ -1,0 +1,33 @@
+# Exercise: RPC-based Authentication Service
+Goal: extend the exemplified RPC infrastructure to support an authentication service
+* The server now has an 'InMemoryAuthenticationService' instance as an attribute to delegate any authentication or token validation requests to.
+* A new class 'RemoteAuthService' is provided that extends the 'ClientStub' and 'AuthenticationService' classes. This is the class responsible for sending requests to invoke the user authentication and token validation procedures.
+* The client command line interface has been extended with the 'auth' and 'validate' commands. The 'auth' command requires the user's id and password parameters and accepts an additional parameter indicating the path and name of the file in which to store the token. The 'validate' command only requires the parameter indicating the path to the token file. 
+* The Serializer's '_datetime_to_ast' method and the Deserializer's '_ast_to_datetime' method have been implemented to serialize and deserialize, respectively, a datetime object.
+
+
+## Running the server
+
+Start the server with:
+```
+poetry run python -m snippets -l 4 -e 2 PORT
+```
+where PORT is the port number the server will listen to, e.g. 8080
+
+## Running the client
+
+Authentication command:
+```bash
+python -m snippets -l 4 -e 4 SERVER_IP:PORT auth -u name -p password [-tp] [--tokenPath filepath]
+```
+
+Token validation command:
+```bash
+python -m snippets -l 4 -e 4 SERVER_IP:PORT validate -u name -p password [-tp] [--tokenPath filepath]
+```
+where:
+* SERVER_IP (e.g. localhost) is the IP address of the server;
+* PORT is the port number the server is listening to (e.g. 8080);
+* name is the user's id;
+* password is the user's password;
+* filepath is the path of the file to store the token into. 

--- a/snippets/lab4/README.md
+++ b/snippets/lab4/README.md
@@ -1,10 +1,11 @@
-# Exercise: RPC-based Authentication Service
-Goal: extend the exemplified RPC infrastructure to support an authentication service
-* The server now has an 'InMemoryAuthenticationService' instance as an attribute to delegate any authentication or token validation requests to.
-* A new class 'RemoteAuthService' is provided that extends the 'ClientStub' and 'AuthenticationService' classes. This is the class responsible for sending requests to invoke the user authentication and token validation procedures.
-* The client command line interface has been extended with the 'auth' and 'validate' commands. The 'auth' command requires the user's id and password parameters and accepts an additional parameter indicating the path and name of the file in which to store the token. The 'validate' command only requires the parameter indicating the path to the token file. 
-* The Serializer's '_datetime_to_ast' method and the Deserializer's '_ast_to_datetime' method have been implemented to serialize and deserialize, respectively, a datetime object.
-
+# Exercise: RPC-based Authentication Service 2
+Goal: extend the exemplified RPC infrastructure to support authorization
+* The Request class has been updated with a new field, metadata, which is a tuple that can be left empty.
+* The server now validates the user's authentication before handling the get_user procedure. Specifically:
+    * If no authentication token is provided, the server responds with an error: "Missing authentication token."
+    * If the provided token is invalid, the server returns an error: "Request not allowed. Authentication required."
+    * If the user is not an admin, the server responds with: "Request not allowed. User is not authorized."
+* The client stores the authentication token received during login and includes it in subsequent get_user requests to the server.
 
 ## Running the server
 
@@ -16,18 +17,13 @@ where PORT is the port number the server will listen to, e.g. 8080
 
 ## Running the client
 
-Authentication command:
+Command to get the info of a user:
 ```bash
-python -m snippets -l 4 -e 4 SERVER_IP:PORT auth -u name -p password [-tp] [--tokenPath filepath]
+python -m snippets -l 4 -e 4 SERVER_IP:PORT get -u name -tp filepath
 ```
 
-Token validation command:
-```bash
-python -m snippets -l 4 -e 4 SERVER_IP:PORT validate -tp filepath
-```
 where:
 * SERVER_IP (e.g. localhost) is the IP address of the server;
 * PORT is the port number the server is listening to (e.g. 8080);
-* name is the user's id;
-* password is the user's password;
-* filepath is the path of the file to store the token into. 
+* name is the id of the user to get details of;
+* filepath is the path of the file where the token is stored into. 

--- a/snippets/lab4/example1_presentation.py
+++ b/snippets/lab4/example1_presentation.py
@@ -12,6 +12,7 @@ class Request:
 
     name: str
     args: tuple
+    metadata: tuple
 
     def __post_init__(self):
         self.args = tuple(self.args)
@@ -86,6 +87,7 @@ class Serializer:
         return {
             'name': self._to_ast(request.name),
             'args': [self._to_ast(arg) for arg in request.args],
+            'metadata': [self._to_ast(data) for data in request.metadata],
         }
 
     def _response_to_ast(self, response: Response):
@@ -147,6 +149,7 @@ class Deserializer:
         return Request(
             name=self._ast_to_obj(data['name']),
             args=tuple(self._ast_to_obj(arg) for arg in data['args']),
+            metadata=tuple(self._ast_to_obj(data) for data in data['metadata']),
         )
 
     def _ast_to_response(self, data):

--- a/snippets/lab4/example1_presentation.py
+++ b/snippets/lab4/example1_presentation.py
@@ -77,7 +77,7 @@ class Serializer:
         }
 
     def _datetime_to_ast(self, dt: datetime):
-        raise NotImplementedError("Missing implementation for datetime serialization")
+        return {'date' : dt.isoformat()}  
 
     def _role_to_ast(self, role: Role):
         return {'name': role.name}
@@ -138,7 +138,7 @@ class Deserializer:
         )
 
     def _ast_to_datetime(self, data):
-        raise NotImplementedError("Missing implementation for datetime deserialization")
+        return datetime.fromisoformat(data['date'])  # Converte l'oggetto datetime in formato stringa ISO 8601
 
     def _ast_to_role(self, data):
         return Role[self._ast_to_obj(data['name'])]

--- a/snippets/lab4/example2_rpc_server.py
+++ b/snippets/lab4/example2_rpc_server.py
@@ -1,5 +1,5 @@
 from snippets.lab3 import Server
-from snippets.lab4.users.impl import InMemoryUserDatabase
+from snippets.lab4.users.impl import InMemoryUserDatabase, InMemoryAuthenticationService
 from snippets.lab4.example1_presentation import serialize, deserialize, Request, Response
 import traceback
 
@@ -8,6 +8,8 @@ class ServerStub(Server):
     def __init__(self, port):
         super().__init__(port, self.__on_connection_event)
         self.__user_db = InMemoryUserDatabase()
+        self.__auth_srvc = InMemoryAuthenticationService(self.__user_db)
+
     
     def __on_connection_event(self, event, connection, address, error):
         match event:
@@ -37,13 +39,33 @@ class ServerStub(Server):
                 print('[%s:%d] Close connection' % connection.remote_address)
     
     def __handle_request(self, request):
+        error = ""
+        auth_error = ""
+        user_db_error = ""
+        
+        try:
+            method = getattr(self.__auth_srvc, request.name)
+            result = method(*request.args)
+            error = None
+        except AttributeError as ae:
+            auth_error = " ".join(ae.args)
+        except Exception as e:
+            result = None
+            error = " ".join(e.args)
+
         try:
             method = getattr(self.__user_db, request.name)
             result = method(*request.args)
             error = None
+        except AttributeError as ae:
+            user_db_error = " ".join(ae.args)
         except Exception as e:
             result = None
             error = " ".join(e.args)
+
+        if auth_error != "" and user_db_error != "":
+            error = auth_error + "\n" + user_db_error
+
         return Response(result, error)
 
 

--- a/snippets/lab4/example2_rpc_server.py
+++ b/snippets/lab4/example2_rpc_server.py
@@ -2,6 +2,7 @@ from snippets.lab3 import Server
 from snippets.lab4.users.impl import InMemoryUserDatabase, InMemoryAuthenticationService
 from snippets.lab4.example1_presentation import serialize, deserialize, Request, Response
 import traceback
+from .users import Token, Role
 
 
 class ServerStub(Server):
@@ -42,6 +43,20 @@ class ServerStub(Server):
         error = ""
         auth_error = ""
         user_db_error = ""
+
+        if request.name == "get_user":
+            try:
+                isinstance(*request.metadata, Token)
+            except Exception as e:
+                result = None
+                return Response(result, "Missing authentication token.")
+            if not self.__auth_srvc.validate_token(*request.metadata):
+                result = None
+                return Response(result, "Request not allowed. Authentication required.")
+            user = self.__user_db.get_user((request.metadata[0]).user.username)
+            if user.role != Role.ADMIN:
+                result = None
+                return Response(result, "Request not allowed. User is not authorized.")
         
         try:
             method = getattr(self.__auth_srvc, request.name)

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -42,6 +42,17 @@ class RemoteUserDatabase(ClientStub, UserDatabase):
     def check_password(self, credentials: Credentials) -> bool:
         return self.rpc('check_password', credentials)
 
+class RemoteAuthService(ClientStub, AuthenticationService):
+    def __init__(self, server_address):
+        super().__init__(server_address)
+    
+    def authenticate(self, credentials: Credentials, duration: timedelta = None) -> Token:
+        return self.rpc('authenticate', credentials, duration)
+
+    def validate_token(self, token: Token) -> bool:
+        return self.rpc('validate_token', token)
+        
+
 
 if __name__ == '__main__':
     from snippets.lab4.example0_users import gc_user, gc_credentials_ok, gc_credentials_wrong

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -7,11 +7,11 @@ class ClientStub:
     def __init__(self, server_address: tuple[str, int]):
         self.__server_address = address(*server_address)
 
-    def rpc(self, name, *args):
+    def rpc(self, name, *args, metadata : tuple = ()):
         client = Client(self.__server_address)
         try:
             print('# Connected to %s:%d' % client.remote_address)
-            request = Request(name, args)
+            request = Request(name, args, metadata)
             print('# Marshalling', request, 'towards', "%s:%d" % client.remote_address)
             request = serialize(request)
             print('# Sending message:', request.replace('\n', '\n# '))
@@ -36,8 +36,11 @@ class RemoteUserDatabase(ClientStub, UserDatabase):
     def add_user(self, user: User):
         return self.rpc('add_user', user)
 
-    def get_user(self, id: str) -> User:
-        return self.rpc('get_user', id)
+    def get_user(self, id: str, token: Token) -> User:
+        metadata = ()
+        if token:
+            metadata = (token,)
+        return self.rpc('get_user', id, metadata=metadata)
 
     def check_password(self, credentials: Credentials) -> bool:
         return self.rpc('check_password', credentials)

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     args.address = address(args.address)
     user_db = RemoteUserDatabase(args.address)
     auth_srvc = RemoteAuthService(args.address)
-    token:Token
+    token:Token = None
 
     try :
         ids = (args.email or []) + [args.user]
@@ -60,7 +60,12 @@ if __name__ == '__main__':
                 f.close()
                 print(auth_srvc.validate_token(token))
             case 'get':
-                print(user_db.get_user(ids[0]))
+                if not args.tokenPath:
+                    raise ValueError("Token file path is required")
+                f = open(args.tokenPath)
+                token = deserialize(f.read())
+                f.close()
+                print(user_db.get_user(ids[0], token))
             case 'check':
                 credentials = Credentials(ids[0], args.password)
                 print(user_db.check_password(credentials))


### PR DESCRIPTION
# Exercise: RPC-based Authentication Service 2
Goal: extend the exemplified RPC infrastructure to support authorization
* The Request class has been updated with a new field, metadata, which is a tuple that can be left empty.
* The server now validates the user's authentication before handling the get_user procedure. Specifically:
    * If no authentication token is provided, the server responds with an error: "Missing authentication token."
    * If the provided token is invalid, the server returns an error: "Request not allowed. Authentication required."
    * If the user is not an admin, the server responds with: "Request not allowed. User is not authorized."
* The client stores the authentication token received during login and includes it in subsequent get_user requests to the server.

## Running the server

Start the server with:
```
poetry run python -m snippets -l 4 -e 2 PORT
```
where PORT is the port number the server will listen to, e.g. 8080

## Running the client

Command to get the info of a user:
```bash
python -m snippets -l 4 -e 4 SERVER_IP:PORT get -u name -tp filepath
```

where:
* SERVER_IP (e.g. localhost) is the IP address of the server;
* PORT is the port number the server is listening to (e.g. 8080);
* name is the id of the user to get details of;
* filepath is the path of the file where the token is stored into. 