### PR TITLE
[A.Y. 2024/2025 Guerra, Nicolò] Exercise: RPC Auth Service 1 & 2

### DIFF
--- a/snippets/lab4/example0_users.py
+++ b/snippets/lab4/example0_users.py
@@ -13,7 +13,7 @@ gc_user = User(
     emails={'giovanni.ciatto@unibo.it', 'giovanni.ciatto@gmail.com'},
     full_name='Giovanni Ciatto',
     role=Role.ADMIN,
-    password='my secret password',
+    password='password',
 )
 
 gc_user_hidden_password = gc_user.copy(password=None)

--- a/snippets/lab4/example1_presentation.py
+++ b/snippets/lab4/example1_presentation.py
@@ -12,11 +12,10 @@ class Request:
 
     name: str
     args: tuple
-    metadata: dict = None
+    metadata: dict
 
     def __post_init__(self):
         self.args = tuple(self.args)
-        self.metadata = self.metadata or {}
 
 
 @dataclass

--- a/snippets/lab4/example2_rpc_server.py
+++ b/snippets/lab4/example2_rpc_server.py
@@ -56,6 +56,8 @@ class ServerStub(Server):
                 elif not self.__auth_service.validate_token(request.metadata['token']):
                     raise ValueError("Invalid authentication token")
                 else:
+                    if request.metadata['token'].user.role != Role.ADMIN:
+                        raise ValueError("Insufficient privileges")                    
                     method = getattr(self.__user_db, request.name)
             result = method(*request.args)
             error = None

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -7,11 +7,12 @@ class ClientStub:
     def __init__(self, server_address: tuple[str, int]):
         self.__server_address = address(*server_address)
 
-    def rpc(self, name, *args, token: Token = None):
+    def rpc(self, name, token: Token = None, *args):
         client = Client(self.__server_address)
         try:
             print('# Connected to %s:%d' % client.remote_address)
-            request = Request(name, args, {'token': token} if token is not None else None)
+            metadata = {'token': token}
+            request = Request(name, args, metadata)
             print('# Marshalling', request, 'towards', "%s:%d" % client.remote_address)
             request = serialize(request)
             print('# Sending message:', request.replace('\n', '\n# '))
@@ -34,16 +35,16 @@ class RemoteUserDatabase(ClientStub, UserDatabase):
         super().__init__(server_address)
 
     def add_user(self, user: User, token: Token = None):
-        return self.rpc('add_user', user, token)
+        return self.rpc('add_user', token, user)
 
     def get_user(self, id: str, token: Token = None) -> User:
-        return self.rpc('get_user', id, token)
+        return self.rpc('get_user', token, id)
 
     def check_password(self, credentials: Credentials, token: Token = None) -> bool:
-        return self.rpc('check_password', credentials, token)
+        return self.rpc('check_password', token, credentials)
 
     def authenticate(self, credentials: Credentials) -> Token:
-        return self.rpc('authenticate', credentials)
+        return self.rpc('authenticate', None, credentials)
 
 if __name__ == '__main__':
     from snippets.lab4.example0_users import gc_user, gc_credentials_ok, gc_credentials_wrong

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -7,11 +7,11 @@ class ClientStub:
     def __init__(self, server_address: tuple[str, int]):
         self.__server_address = address(*server_address)
 
-    def rpc(self, name, *args):
+    def rpc(self, name, *args, token: Token = None):
         client = Client(self.__server_address)
         try:
             print('# Connected to %s:%d' % client.remote_address)
-            request = Request(name, args)
+            request = Request(name, args, {'token': token} if token is not None else None)
             print('# Marshalling', request, 'towards', "%s:%d" % client.remote_address)
             request = serialize(request)
             print('# Sending message:', request.replace('\n', '\n# '))
@@ -33,15 +33,17 @@ class RemoteUserDatabase(ClientStub, UserDatabase):
     def __init__(self, server_address):
         super().__init__(server_address)
 
-    def add_user(self, user: User):
-        return self.rpc('add_user', user)
+    def add_user(self, user: User, token: Token = None):
+        return self.rpc('add_user', user, token)
 
-    def get_user(self, id: str) -> User:
-        return self.rpc('get_user', id)
+    def get_user(self, id: str, token: Token = None) -> User:
+        return self.rpc('get_user', id, token)
 
-    def check_password(self, credentials: Credentials) -> bool:
-        return self.rpc('check_password', credentials)
+    def check_password(self, credentials: Credentials, token: Token = None) -> bool:
+        return self.rpc('check_password', credentials, token)
 
+    def authenticate(self, credentials: Credentials) -> Token:
+        return self.rpc('authenticate', credentials)
 
 if __name__ == '__main__':
     from snippets.lab4.example0_users import gc_user, gc_credentials_ok, gc_credentials_wrong

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -4,6 +4,8 @@ import sys
 
 
 if __name__ == '__main__':
+    'poetry run python -m snippets -l 4 -e 4 127.0.0.1:5000 add --user nico --email "nicolo@email.com" --name Nicolo --role admin --password password'
+    
 
     parser = argparse.ArgumentParser(
         prog=f'python -m snippets -l 4 -e 4',
@@ -11,12 +13,13 @@ if __name__ == '__main__':
         exit_on_error=False,
     )
     parser.add_argument('address', help='Server address in the form ip:port')
-    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check'])
+    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check', 'authenticate'])
     parser.add_argument('--user', '-u', help='Username')
     parser.add_argument('--email', '--address', '-a', nargs='+', help='Email address')
     parser.add_argument('--name', '-n', help='Full name')
     parser.add_argument('--role', '-r', help='Role (defaults to "user")', choices=['admin', 'user'])
     parser.add_argument('--password', '-p', help='Password')
+    parser.add_argument('--token', '-t', help='Authentication token')
 
     if len(sys.argv) > 1:
         args = parser.parse_args()
@@ -44,6 +47,9 @@ if __name__ == '__main__':
             case 'check':
                 credentials = Credentials(ids[0], args.password)
                 print(user_db.check_password(credentials))
+            case 'authenticate':
+                credentials = Credentials(args.user, args.password)
+                print(user_db.authenticate(credentials))
             case _:
                 raise ValueError(f"Invalid command '{args.command}'")
     except RuntimeError as e:

--- a/test/test_exercise_authentication.py
+++ b/test/test_exercise_authentication.py
@@ -6,7 +6,7 @@ from snippets.lab4.example2_rpc_server import ServerStub
 from snippets.lab4.example3_rpc_client import RemoteUserDatabase
 from snippets.lab4.users import Credentials, Role, User
 
-class TestMultiTCPChatPeer(unittest.TestCase):
+class TestAuthenticationRemoteDB(unittest.TestCase):
     TIMEOUT = 5
     PORT = 12345
     ADMIN_CREDS = Credentials('admin', 'admin')
@@ -79,6 +79,3 @@ class TestMultiTCPChatPeer(unittest.TestCase):
         token = self.client.authenticate(Credentials('test', 'test'))
         self.assertIsNotNone(token, "Token is None")
         self.assertRaises(RuntimeError, self.client.get_user, 'admin', token)
-        
-        
-    

--- a/test/test_exercise_authentication.py
+++ b/test/test_exercise_authentication.py
@@ -1,0 +1,84 @@
+from threading import Thread
+from time import sleep, time
+import unittest
+from unittest.mock import MagicMock, patch
+from snippets.lab4.example2_rpc_server import ServerStub
+from snippets.lab4.example3_rpc_client import RemoteUserDatabase
+from snippets.lab4.users import Credentials, Role, User
+
+class TestMultiTCPChatPeer(unittest.TestCase):
+    TIMEOUT = 5
+    PORT = 12345
+    ADMIN_CREDS = Credentials('admin', 'admin')
+
+    def setUp(self):
+        self.server_stub = ServerStub(self.PORT)
+        self.client = RemoteUserDatabase(('127.0.0.1',self.PORT))
+        
+    def tearDown(self):
+        self.server_stub.close()
+        
+    def test_default_admin_login(self):
+        credentials = self.ADMIN_CREDS
+        token = self.client.authenticate(credentials)
+        self.assertIsNotNone(token, "Token is None")
+        
+    def test_default_admin_login_wrong_password(self):
+        credentials = Credentials('admin', 'wrong')
+        try:
+            self.client.authenticate(credentials)
+        except RuntimeError as e:
+            self.assertTrue('Invalid credentials' in str(e), "Unexpected error message")
+        except Exception as e:
+            self.fail("Unexpected exception: %s" % e)
+        
+    def test_login_wrong_username(self):
+        credentials = Credentials('wrong', 'admin')
+        try:
+            self.client.authenticate(credentials)
+        except RuntimeError as e:
+            self.assertTrue('Invalid credentials' in str(e), "Unexpected error message")
+        except Exception as e:
+            self.fail("Unexpected exception: %s" % e)
+            
+    def test_get_withouth_login(self):
+        self.assertRaises(RuntimeError, self.client.get_user, 'admin')
+        
+    def test_add_withouth_login(self):
+        self.assertRaises(RuntimeError, self.client.add_user, 'admin')
+        
+    def test_check_withouth_login(self):
+        self.assertRaises(RuntimeError, self.client.check_password, 'admin')
+        
+    def test_login_and_get(self):
+        credentials = self.ADMIN_CREDS
+        token = self.client.authenticate(credentials)
+        self.assertIsNotNone(token, "Token is None")
+        user = self.client.get_user('admin', token)
+        self.assertEqual(user.username, 'admin', "Got wrong user")
+        
+    def test_login_and_add(self):
+        credentials = self.ADMIN_CREDS
+        token = self.client.authenticate(credentials)
+        self.assertIsNotNone(token, "Token is None")
+        user = User('test', ['test@localhost'], 'Test User', Role.USER, 'test')
+        self.client.add_user(user, token)
+        got_user = self.client.get_user('test', token)
+        user.password=None
+        self.assertEqual(got_user, user, "User returned is not the same as the one added")
+        
+    def test_unauthorized_get(self):
+        credentials = self.ADMIN_CREDS
+        token = self.client.authenticate(credentials)
+        self.assertIsNotNone(token, "Token is None")
+        user = User('test', ['test@localhost'], 'Test User', Role.USER, 'test')
+        self.client.add_user(user, token)
+        got_user = self.client.get_user('test', token)
+        user.password=None
+        self.assertEqual(got_user, user, "User returned is not the same as the one added")
+        token = self.client.authenticate(Credentials('test', 'test'))
+        self.assertIsNotNone(token, "Token is None")
+        self.assertRaises(RuntimeError, self.client.get_user, 'admin', token)
+        
+        
+    


### PR DESCRIPTION
Added metadata dictionary field in Request class to store the token, modified serialize and deserialize methods accordingly. Added datetime serialization which raised UnimplementedError.
By default the user db contains an admin user with username 'admin' and password 'admin'. The user is created on the first run of the server and is needed to add or modify users.
The server checks the token validity in the request and the user role (delegating the job to an InMemoryAuthenticationService), ADMIN role is required to do all the operations except for the authentication request. The remote user database object doesn't save the token, instead it returns it to the caller that has to save it, for this reason the CLI client has been modified in order to serialize and save it on a text file (the file name can be specified via command line parameters, by default it is "token.txt"). Tests made with unittests module are available in `test/test_exercise_authentication.py`

To run the server use the following command:
```bash
poetry run python -m snippets -l 4 -e 2 PORT
```

To run the CLI client use the following command:
```bash
poetry run python -m snippets -l 4 -e 4 [--user USER] [--email EMAIL [EMAIL ...]] [--name NAME] [--role {admin,user}] [--password PASSWORD] [--token-file TOKEN_FILE] address {add,get,check,authenticate}
```