### PR TITLE
[A.Y. 2024/2025 Giacobbi, Domenico] Exercise: RPC Auth Service

### DIFF
--- a/snippets/lab4/README.md
+++ b/snippets/lab4/README.md
@@ -9,13 +9,17 @@ Another client stub has been created for the AuthenticationService interface.
 The authenticate and validate commands have been added to the cli client, to perform authentication and authentication validation.
 
 To start the server:
+
 ``` python -m snippets -l 4 -e 2 PORT ```
 
 To authenticate in the client cli:
+
 ``` python -m snippets -l 4 -e 4 SERVER_PORT:PORT authenticate -u USER -p PASSWORD -t TOKEN_FILE_NAME```
+
 If the file is not specified, token_file.json is used
 
 To validate in the client cli:
+
 ``` python -m snippets -l 4 -e 4 localhost:807 validate -t TOKEN_FILE_NAME ```
 
 TOKEN_FILE_NAME is the path of the file where the token is saved

--- a/snippets/lab4/README.md
+++ b/snippets/lab4/README.md
@@ -1,0 +1,21 @@
+# Exercise: RPC-based Authentication Service
+
+An extension of the exemplified RPC infrastructure has been created to support an authentication service.
+
+In particular, the server stub delegates the actual work to an actual instance of InMemoryAuthenticationService. 
+
+Another client stub has been created for the AuthenticationService interface.
+
+The authenticate and validate commands have been added to the cli client, to perform authentication and authentication validation.
+
+To start the server:
+``` python -m snippets -l 4 -e 2 PORT ```
+
+To authenticate in the client cli:
+``` python -m snippets -l 4 -e 4 SERVER_PORT:PORT authenticate -u USER -p PASSWORD -t TOKEN_FILE_NAME```
+If the file is not specified, token_file.json is used
+
+To validate in the client cli:
+``` python -m snippets -l 4 -e 4 localhost:807 validate -t TOKEN_FILE_NAME ```
+
+TOKEN_FILE_NAME is the path of the file where the token is saved

--- a/snippets/lab4/example1_presentation.py
+++ b/snippets/lab4/example1_presentation.py
@@ -77,7 +77,10 @@ class Serializer:
         }
 
     def _datetime_to_ast(self, dt: datetime):
-        raise NotImplementedError("Missing implementation for datetime serialization")
+        return {
+            'date_time' : self._to_ast(dt.isoformat())
+        }
+        #raise NotImplementedError("Missing implementation for datetime serialization")
 
     def _role_to_ast(self, role: Role):
         return {'name': role.name}
@@ -138,7 +141,8 @@ class Deserializer:
         )
 
     def _ast_to_datetime(self, data):
-        raise NotImplementedError("Missing implementation for datetime deserialization")
+        return datetime.fromisoformat(data['date_time'])
+        #raise NotImplementedError("Missing implementation for datetime deserialization")
 
     def _ast_to_role(self, data):
         return Role[self._ast_to_obj(data['name'])]

--- a/snippets/lab4/example2_rpc_server.py
+++ b/snippets/lab4/example2_rpc_server.py
@@ -62,7 +62,7 @@ class ServerStub(Server):
             result = None
             error = " ".join(e.args)
 
-        #if message_db_error and message_auth_error:
+        if message_db_error and message_auth_error:
             error = "db:"+ message_db_error + "\nauth:" + message_auth_error
 
 

--- a/snippets/lab4/example3_rpc_client.py
+++ b/snippets/lab4/example3_rpc_client.py
@@ -42,6 +42,17 @@ class RemoteUserDatabase(ClientStub, UserDatabase):
     def check_password(self, credentials: Credentials) -> bool:
         return self.rpc('check_password', credentials)
 
+class RemoteAuthDatabase(ClientStub, AuthenticationService):
+    def __init__(self, server_address):
+        super().__init__(server_address)
+    
+    def authenticate(self, credentials: Credentials):
+        return self.rpc('authenticate', credentials)
+
+    def validate_token(self, token: Token) -> bool:
+        return self.rpc('validate_token', token)
+
+
 
 if __name__ == '__main__':
     from snippets.lab4.example0_users import gc_user, gc_credentials_ok, gc_credentials_wrong
@@ -63,6 +74,7 @@ if __name__ == '__main__':
     try:
         user_db.add_user(gc_user)
     except RuntimeError as e:
+
         assert str(e).startswith('User with ID')
         assert str(e).endswith('already exists')
 

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -4,8 +4,6 @@ import sys
 import os
 
 
-
-TOKEN_DIR  = os.getcwd()
 TOKEN_DEFAULT_FILE = "token_file.json"
 
 def write_token(token:Token, token_file = TOKEN_DEFAULT_FILE):
@@ -15,6 +13,8 @@ def write_token(token:Token, token_file = TOKEN_DEFAULT_FILE):
     file.close()
 
 def read_token(token_file = TOKEN_DEFAULT_FILE):
+    if not os.path.exists(token_file):
+        raise ValueError("The file does not exist.")
     file = open(token_file, "r")
     read_file = file.read()
     deserialized_token = deserialize(read_file)
@@ -51,8 +51,6 @@ if __name__ == '__main__':
     try :
         ids = (args.email or []) + [args.user]
 
-
-
         file_name = TOKEN_DEFAULT_FILE
 
         if args.token_file_path:
@@ -81,7 +79,6 @@ if __name__ == '__main__':
                 print("Authentication successful")
             case 'validate':
                 if not args.token_file_path:
-                    print(Hello)
                     raise ValueError("Unspecified file")
                 token = read_token(file_name)
                 if authentication_service.validate_token(token):

--- a/snippets/lab4/example4_rpc_client_cli.py
+++ b/snippets/lab4/example4_rpc_client_cli.py
@@ -1,6 +1,24 @@
 from .example3_rpc_client import *
 import argparse
 import sys
+import os
+
+
+
+TOKEN_DIR  = os.getcwd()
+TOKEN_DEFAULT_FILE = "token_file.json"
+
+def write_token(token:Token, token_file = TOKEN_DEFAULT_FILE):
+    file = open(token_file, "w")
+    serialized_token = serialize(token)
+    file.write(serialized_token)
+    file.close()
+
+def read_token(token_file = TOKEN_DEFAULT_FILE):
+    file = open(token_file, "r")
+    read_file = file.read()
+    deserialized_token = deserialize(read_file)
+    return deserialized_token
 
 
 if __name__ == '__main__':
@@ -10,13 +28,15 @@ if __name__ == '__main__':
         description='RPC client for user database',
         exit_on_error=False,
     )
+
     parser.add_argument('address', help='Server address in the form ip:port')
-    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check'])
+    parser.add_argument('command', help='Method to call', choices=['add', 'get', 'check', 'authenticate', 'validate'])
     parser.add_argument('--user', '-u', help='Username')
     parser.add_argument('--email', '--address', '-a', nargs='+', help='Email address')
     parser.add_argument('--name', '-n', help='Full name')
     parser.add_argument('--role', '-r', help='Role (defaults to "user")', choices=['admin', 'user'])
     parser.add_argument('--password', '-p', help='Password')
+    parser.add_argument('--token_file_path', '-t', help='Token File Path')
 
     if len(sys.argv) > 1:
         args = parser.parse_args()
@@ -26,9 +46,18 @@ if __name__ == '__main__':
 
     args.address = address(args.address)
     user_db = RemoteUserDatabase(args.address)
+    authentication_service = RemoteAuthDatabase(args.address)
 
     try :
         ids = (args.email or []) + [args.user]
+
+
+
+        file_name = TOKEN_DEFAULT_FILE
+
+        if args.token_file_path:
+            file_name = args.token_file_path
+
         if len(ids) == 0:
             raise ValueError("Username or email address is required")
         match args.command:
@@ -44,6 +73,21 @@ if __name__ == '__main__':
             case 'check':
                 credentials = Credentials(ids[0], args.password)
                 print(user_db.check_password(credentials))
+            case 'authenticate':
+                credentials = Credentials(ids[0], args.password)
+                token = authentication_service.authenticate(credentials)
+                write_token(token, file_name)
+                print("Generated token:" + token.signature)
+                print("Authentication successful")
+            case 'validate':
+                if not args.token_file_path:
+                    print(Hello)
+                    raise ValueError("Unspecified file")
+                token = read_token(file_name)
+                if authentication_service.validate_token(token):
+                    print("Token with signature:" + token.signature + " is validated")
+                else:
+                    print("Token is not validated")
             case _:
                 raise ValueError(f"Invalid command '{args.command}'")
     except RuntimeError as e:


### PR DESCRIPTION
# Exercise: RPC-based Authentication Service

An extension of the exemplified RPC infrastructure has been created to support an authentication service.

In particular, the server stub delegates the actual work to an actual instance of InMemoryAuthenticationService. 

Another client stub has been created for the AuthenticationService interface.

The authenticate and validate commands have been added to the cli client, to perform authentication and authentication validation.

To start the server:

``` python -m snippets -l 4 -e 2 PORT ```

To authenticate in the client cli:

``` python -m snippets -l 4 -e 4 SERVER_PORT:PORT authenticate -u USER -p PASSWORD -t TOKEN_FILE_NAME```

If the file is not specified, token_file.json is used

To validate in the client cli:

``` python -m snippets -l 4 -e 4 localhost:807 validate -t TOKEN_FILE_NAME ```

TOKEN_FILE_NAME is the path of the file where the token is saved
